### PR TITLE
Release v0.1.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0] - 2025-02-07
+## [0.1.0-alpha.1] - 2026-02-07
 
 ### Added
 - Initial release of sqlsurge
@@ -42,5 +42,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - No support for VIEWs, functions, or stored procedures
 - Derived table (subquery in FROM) column resolution is incomplete
 
-[Unreleased]: https://github.com/yukikotani231/sqlsurge/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/yukikotani231/sqlsurge/releases/tag/v0.1.0
+[Unreleased]: https://github.com/yukikotani231/sqlsurge/compare/v0.1.0-alpha.1...HEAD
+[0.1.0-alpha.1]: https://github.com/yukikotani231/sqlsurge/releases/tag/v0.1.0-alpha.1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ sqlsurge/
 
 1. **SchemaBuilder** (`schema/builder.rs`): Parses CREATE TABLE statements using sqlparser-rs and builds a `Catalog`
 2. **Catalog** (`schema/catalog.rs`): In-memory representation of database schema (tables, columns, constraints)
-3. **Analyzer** (`analyzer/mod.rs`): Entry point for query validation (28 comprehensive tests)
+3. **Analyzer** (`analyzer/mod.rs`): Entry point for query validation (35 comprehensive tests)
 4. **NameResolver** (`analyzer/resolver.rs`): Resolves table and column references, supports CTEs with scope isolation
 5. **SqlType** (`types/mod.rs`): Internal SQL type representation with compatibility checking
 6. **Config** (`config.rs`): Configuration file loader with hierarchical merging (file < CLI args)
@@ -118,7 +118,7 @@ cargo run -- check --format sarif --schema schema.sql query.sql
 - Unit tests are colocated with modules (`#[cfg(test)] mod tests`)
 - Integration tests use SQL fixtures in `tests/fixtures/`
 - Test both positive cases (valid SQL) and negative cases (should produce diagnostics)
-- Comprehensive test coverage: 28 tests covering SELECT, INSERT, UPDATE, DELETE, CTEs, subqueries
+- Comprehensive test coverage: 35 tests covering SELECT, INSERT, UPDATE, DELETE, CTEs, subqueries
 - Test-driven development (TDD) approach: write failing tests first, then implement features
 
 ## Style Guidelines

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/sqlsurge-core", "crates/sqlsurge-cli"]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.1.0-alpha.1"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/yukikotani231/sqlsurge"
@@ -32,7 +32,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 glob = "0.3"
 
 # Internal crates
-sqlsurge-core = { path = "crates/sqlsurge-core" }
+sqlsurge-core = { path = "crates/sqlsurge-core", version = "0.1.0-alpha.1" }
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -73,7 +73,11 @@ This document describes how to publish sqlsurge to crates.io and npm.
 
 ## Publishing to npm
 
-See `npm/README.md` for npm publishing instructions.
+npm publishing is handled automatically by cargo-dist.
+When a version tag (e.g., `v0.1.0`) is pushed, the GitHub Actions release workflow
+builds platform-specific binaries and publishes the npm package (`sqlsurge-cli`).
+
+**Prerequisite:** Set `NPM_TOKEN` in GitHub repository secrets.
 
 ## Post-publish
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 # sqlsurge
 
 [![CI](https://github.com/yukikotani231/sqlsurge/actions/workflows/ci.yml/badge.svg)](https://github.com/yukikotani231/sqlsurge/actions/workflows/ci.yml)
-[![Crates.io](https://img.shields.io/crates/v/sqlsurge.svg)](https://crates.io/crates/sqlsurge)
+[![Crates.io](https://img.shields.io/crates/v/sqlsurge-cli.svg)](https://crates.io/crates/sqlsurge-cli)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 
 **SQL static analyzer that validates queries against schema definitions — no database connection required.**
 
 sqlsurge parses your schema DDL files and validates SQL queries at build time, catching errors like missing tables, unknown columns, and typos before they reach production.
+
+> **Note:** sqlsurge is in early development (alpha). APIs and diagnostics may change between versions. Feedback and contributions are welcome!
 
 ## Features
 
@@ -38,7 +40,7 @@ cargo install sqlsurge-cli
 
 ### From GitHub Releases
 
-Download the latest binary from [Releases](https://github.com/yukikotani/sqlsurge/releases).
+Download the latest binary from [Releases](https://github.com/yukikotani231/sqlsurge/releases).
 
 ## Quick Start
 
@@ -132,16 +134,19 @@ sqlsurge check --schema schema/*.sql queries/**/*.sql
 sqlsurge check [OPTIONS] <FILES>...
 
 Arguments:
-  <FILES>...              SQL files to validate (supports glob patterns)
+  <FILES>...                SQL files to validate (supports glob patterns)
 
 Options:
-  -s, --schema <FILE>     Schema definition file (can be specified multiple times)
-      --schema-dir <DIR>  Directory containing schema files
-  -d, --dialect <NAME>    SQL dialect [default: postgresql]
-  -f, --format <FORMAT>   Output format: human, json, sarif [default: human]
-  -v, --verbose           Enable verbose output
-  -q, --quiet             Suppress non-error output
-  -h, --help              Print help
+  -s, --schema <FILE>       Schema definition file (can be specified multiple times)
+      --schema-dir <DIR>    Directory containing schema files
+  -c, --config <FILE>       Path to configuration file [default: sqlsurge.toml]
+      --disable <RULE>      Disable specific rules (e.g., E0001, E0002)
+  -d, --dialect <NAME>      SQL dialect [default: postgresql]
+  -f, --format <FORMAT>     Output format: human, json, sarif [default: human]
+      --max-errors <N>      Maximum number of errors before stopping [default: 100]
+  -v, --verbose             Enable verbose output
+  -q, --quiet               Suppress non-error output
+  -h, --help                Print help
 ```
 
 ## Output Formats
@@ -178,7 +183,7 @@ sqlsurge check -s schema.sql -f sarif queries/*.sql > results.sarif
 
 ## Roadmap
 
-- [ ] Configuration file (`sqlsurge.toml`)
+- [x] Configuration file (`sqlsurge.toml`)
 - [ ] LSP server for editor integration
 - [ ] MySQL and SQLite dialect support
 - [ ] Type inference for expressions

--- a/crates/sqlsurge-cli/src/main.rs
+++ b/crates/sqlsurge-cli/src/main.rs
@@ -66,11 +66,8 @@ fn run(args: Args) -> Result<bool> {
             let config = config.merge_with_args(&schema, &schema_dir, &files, &format, &disable);
 
             // Get schema files from config or CLI
-            let mut schema_files: Vec<std::path::PathBuf> = config
-                .schema
-                .iter()
-                .map(|s| std::path::PathBuf::from(s))
-                .collect();
+            let mut schema_files: Vec<std::path::PathBuf> =
+                config.schema.iter().map(std::path::PathBuf::from).collect();
 
             if let Some(dir) = &config.schema_dir {
                 let pattern = format!("{}/**/*.sql", dir);
@@ -99,7 +96,8 @@ fn run(args: Args) -> Result<bool> {
             for schema_file in &schema_files {
                 let content = fs::read_to_string(schema_file).into_diagnostic()?;
                 if let Err(diags) = builder.parse(&content) {
-                    let formatter = OutputFormatter::new(output_format, schema_file.display().to_string());
+                    let formatter =
+                        OutputFormatter::new(output_format, schema_file.display().to_string());
                     formatter.print_diagnostics(&diags, &content);
                     return Ok(true);
                 }
@@ -116,7 +114,7 @@ fn run(args: Args) -> Result<bool> {
             // Collect query files from config or CLI
             let mut query_files = Vec::new();
             let file_patterns: Vec<std::path::PathBuf> = if !config.files.is_empty() {
-                config.files.iter().map(|s| std::path::PathBuf::from(s)).collect()
+                config.files.iter().map(std::path::PathBuf::from).collect()
             } else {
                 vec![]
             };
@@ -142,7 +140,8 @@ fn run(args: Args) -> Result<bool> {
             let mut analyzer = Analyzer::new(&catalog);
 
             // Get disabled rules
-            let disabled_rules: std::collections::HashSet<String> = config.disable.iter().cloned().collect();
+            let disabled_rules: std::collections::HashSet<String> =
+                config.disable.iter().cloned().collect();
 
             for query_file in &query_files {
                 let content = fs::read_to_string(query_file).into_diagnostic()?;
@@ -155,7 +154,8 @@ fn run(args: Args) -> Result<bool> {
                     .collect();
 
                 if !filtered_diagnostics.is_empty() {
-                    let formatter = OutputFormatter::new(output_format, query_file.display().to_string());
+                    let formatter =
+                        OutputFormatter::new(output_format, query_file.display().to_string());
                     formatter.print_diagnostics(&filtered_diagnostics, &content);
 
                     for diag in &filtered_diagnostics {


### PR DESCRIPTION
## Summary

- Add early development notice to README
- Update version to 0.1.0-alpha.1
- Fix documentation inaccuracies (crates.io badge URL, GitHub URL, CLI reference, Roadmap)
- Fix cargo fmt / clippy warnings
- Add version to sqlsurge-core workspace dependency for crates.io publishing
- Update PUBLISHING.md npm section for cargo-dist

## Pre-release checklist

- [x] `cargo fmt --check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` passes (35 tests)
- [x] `cargo package -p sqlsurge-core` succeeds
- [x] Documentation reviewed and corrected

## After merge

1. `cargo publish -p sqlsurge-core`
2. `cargo publish -p sqlsurge-cli`
3. `git tag v0.1.0-alpha.1 && git push origin v0.1.0-alpha.1`
4. GitHub Actions will auto-create release and publish npm package

🤖 Generated with [Claude Code](https://claude.com/claude-code)