### PR TITLE
Add release automation

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,48 @@
+name: Auto Tag Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    # Only run when a release branch PR is merged (not just closed)
+    if: >
+      github.event.pull_request.merged == true &&
+      startsWith(github.event.pull_request.head.ref, 'release/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Extract version from branch name
+        id: version
+        run: |
+          BRANCH="${{ github.event.pull_request.head.ref }}"
+          TAG="${BRANCH#release/}"
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "Detected tag: ${TAG}"
+
+      - name: Verify version matches Cargo.toml
+        run: |
+          EXPECTED="${{ steps.version.outputs.tag }}"
+          EXPECTED_VERSION="${EXPECTED#v}"
+          ACTUAL=$(grep -m1 'version = ' Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
+          if [ "$ACTUAL" != "$EXPECTED_VERSION" ]; then
+            echo "ERROR: Cargo.toml version ($ACTUAL) does not match tag ($EXPECTED_VERSION)"
+            exit 1
+          fi
+          echo "Version verified: $ACTUAL"
+
+      - name: Create and push tag
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          git tag "$TAG"
+          git push origin "$TAG"
+          echo "Tag ${TAG} created and pushed. Release workflow will start automatically."

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,83 +1,51 @@
 # Publishing Guide
 
-This document describes how to publish sqlsurge to crates.io and npm.
+This document describes how to publish sqlsurge releases.
+
+## Quick Release (Recommended)
+
+Use the release script for a streamlined process:
+
+```bash
+# 1. Prepare the release (updates version, CHANGELOG, creates PR)
+./scripts/release.sh 0.2.0
+
+# 2. Edit CHANGELOG.md when prompted, then press Enter
+
+# 3. Review and merge the PR on GitHub
+#    -> Tag is created automatically
+#    -> Release workflow builds and publishes automatically
+```
+
+The script handles:
+- Version bump in `Cargo.toml`
+- `Cargo.lock` update
+- `CHANGELOG.md` scaffolding
+- Running tests, clippy, and fmt checks
+- Creating a release branch, commit, and PR
+
+After the PR is merged:
+1. `auto-tag.yml` workflow detects the merged `release/v*` branch and creates the git tag
+2. The tag triggers `release.yml` (cargo-dist) which automatically:
+   - Builds platform-specific binaries (macOS, Linux, Windows)
+   - Creates a GitHub Release with artifacts
+   - Publishes the npm package (`sqlsurge-cli`)
 
 ## Prerequisites
 
-### For crates.io
+### For npm
+- Set `NPM_TOKEN` in GitHub repository secrets
+- npm publishing is handled automatically by cargo-dist
+
+### For crates.io (manual, if needed)
 1. Create an account on [crates.io](https://crates.io/)
 2. Get an API token: `cargo login`
-3. Ensure you're a member/owner of the crates
-
-### For npm
-1. Create an account on [npmjs.com](https://www.npmjs.com/)
-2. Login: `npm login`
-3. (Optional) Create an organization for scoped packages
-
-## Publishing to crates.io
-
-### Pre-publish Checklist
-- [ ] All tests pass: `cargo test --workspace`
-- [ ] Clippy is clean: `cargo clippy --all-targets -- -D warnings`
-- [ ] Format is correct: `cargo fmt --check`
-- [ ] Documentation builds: `cargo doc --no-deps`
-- [ ] Version updated in `Cargo.toml` (workspace.package.version)
-- [ ] CHANGELOG.md updated with new version
-- [ ] README.md is up to date
-- [ ] All changes committed to git
-- [ ] Git tag created: `git tag v0.1.0`
-
-### Publishing Steps
-
-1. **Dry run (verify package contents)**
+3. Publish core first, then CLI:
    ```bash
-   cargo package --list
+   cd crates/sqlsurge-core && cargo publish && cd ../..
+   # Wait a few minutes for index update
+   cd crates/sqlsurge-cli && cargo publish && cd ../..
    ```
-
-2. **Test the package builds**
-   ```bash
-   cargo package
-   ```
-
-3. **Publish sqlsurge-core first** (dependency must be published first)
-   ```bash
-   cd crates/sqlsurge-core
-   cargo publish
-   cd ../..
-   ```
-
-4. **Wait for core to be available** (usually takes a few minutes)
-   ```bash
-   # Check if it's available
-   cargo search sqlsurge-core
-   ```
-
-5. **Publish sqlsurge-cli**
-   ```bash
-   cd crates/sqlsurge-cli
-   cargo publish
-   cd ../..
-   ```
-
-6. **Push tags to GitHub**
-   ```bash
-   git push origin main
-   git push origin v0.1.0
-   ```
-
-7. **Create GitHub Release**
-   - Go to https://github.com/yukikotani231/sqlsurge/releases/new
-   - Select the tag you just pushed
-   - Copy the CHANGELOG entry for this version
-   - Publish release
-
-## Publishing to npm
-
-npm publishing is handled automatically by cargo-dist.
-When a version tag (e.g., `v0.1.0`) is pushed, the GitHub Actions release workflow
-builds platform-specific binaries and publishes the npm package (`sqlsurge-cli`).
-
-**Prerequisite:** Set `NPM_TOKEN` in GitHub repository secrets.
 
 ## Post-publish
 
@@ -92,15 +60,8 @@ builds platform-specific binaries and publishes the npm package (`sqlsurge-cli`)
    mkdir test-sqlsurge && cd test-sqlsurge
    cargo init
    cargo add sqlsurge-core
-   # Write a simple test
    cargo test
    ```
-
-3. **Announce**
-   - Twitter/X
-   - Reddit (r/rust)
-   - This Week in Rust
-   - Rust Users Forum
 
 ## Version Strategy
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Usage: ./scripts/release.sh <version>
+# Example: ./scripts/release.sh 0.1.0-alpha.4
+#
+# This script automates the release process:
+# 1. Updates version in Cargo.toml (workspace + dependency)
+# 2. Updates Cargo.lock
+# 3. Adds a new section to CHANGELOG.md
+# 4. Runs tests, clippy, and fmt checks
+# 5. Creates a release branch, commits, and pushes
+# 6. Creates a PR via gh CLI
+#
+# After the PR is merged, the auto-tag workflow (.github/workflows/auto-tag.yml)
+# automatically creates and pushes the git tag, which triggers the release workflow.
+#
+# Manual tagging (if needed): ./scripts/release.sh --tag <version>
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+# --- Tag mode ---
+if [[ "${1:-}" == "--tag" ]]; then
+    VERSION="${2:?Usage: $0 --tag <version>}"
+    TAG="v${VERSION}"
+
+    echo "==> Switching to main and pulling latest..."
+    git checkout main
+    git pull origin main
+
+    # Verify the version matches
+    CURRENT_VERSION=$(grep -m1 'version = ' Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
+    if [[ "$CURRENT_VERSION" != "$VERSION" ]]; then
+        echo "ERROR: Cargo.toml version ($CURRENT_VERSION) does not match requested version ($VERSION)"
+        exit 1
+    fi
+
+    echo "==> Creating tag ${TAG}..."
+    git tag "$TAG"
+    git push origin "$TAG"
+    echo ""
+    echo "Tag ${TAG} pushed. The release workflow will build and publish automatically."
+    echo "Monitor progress: gh run list --limit 3"
+    exit 0
+fi
+
+# --- Release prep mode ---
+VERSION="${1:?Usage: $0 <version>}"
+TAG="v${VERSION}"
+
+# Validate version format
+if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+'; then
+    echo "ERROR: Version must be in semver format (e.g., 0.1.0, 0.1.0-alpha.4)"
+    exit 1
+fi
+
+# Check prerequisites
+command -v gh >/dev/null 2>&1 || { echo "ERROR: gh CLI is required. Install: https://cli.github.com/"; exit 1; }
+
+# Check for clean working tree
+if ! git diff --quiet || ! git diff --cached --quiet; then
+    echo "ERROR: Working tree is not clean. Commit or stash changes first."
+    exit 1
+fi
+
+# Check we're on main
+BRANCH=$(git branch --show-current)
+if [[ "$BRANCH" != "main" ]]; then
+    echo "ERROR: Must be on main branch (currently on: $BRANCH)"
+    exit 1
+fi
+
+# Get current version
+OLD_VERSION=$(grep -m1 'version = ' Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
+echo "==> Updating version: ${OLD_VERSION} -> ${VERSION}"
+
+# 1. Update version in Cargo.toml
+sed -i '' "s/version = \"${OLD_VERSION}\"/version = \"${VERSION}\"/g" Cargo.toml
+echo "    Updated Cargo.toml"
+
+# 2. Update Cargo.lock
+cargo check --quiet 2>/dev/null
+echo "    Updated Cargo.lock"
+
+# 3. Update CHANGELOG.md
+TODAY=$(date +%Y-%m-%d)
+CHANGELOG_ENTRY="## [${VERSION}] - ${TODAY}
+
+### Added
+
+### Fixed
+
+### Changed
+"
+
+# Insert after [Unreleased] line
+sed -i '' "/^## \[Unreleased\]$/a\\
+\\
+${CHANGELOG_ENTRY}" CHANGELOG.md
+
+# Update links at bottom
+sed -i '' "s|\[Unreleased\]: \(.*\)/compare/v${OLD_VERSION}\.\.\.HEAD|[Unreleased]: \1/compare/v${VERSION}...HEAD\n[${VERSION}]: \1/compare/v${OLD_VERSION}...v${VERSION}|" CHANGELOG.md
+
+echo "    Updated CHANGELOG.md (please edit the entries before committing)"
+
+# 4. Run checks
+echo "==> Running checks..."
+cargo test --quiet 2>&1
+echo "    Tests passed"
+cargo clippy --all-targets -- -D warnings 2>&1 | tail -1
+echo "    Clippy passed"
+cargo fmt --check 2>&1
+echo "    Format OK"
+
+# 5. Open CHANGELOG for editing
+echo ""
+echo "==> CHANGELOG.md has been prepared with empty sections."
+echo "    Please edit it now to add the release notes."
+echo ""
+read -p "Press Enter when CHANGELOG.md is ready (or Ctrl+C to abort)..."
+
+# 6. Create release branch, commit, push, and PR
+RELEASE_BRANCH="release/v${VERSION}"
+echo "==> Creating branch ${RELEASE_BRANCH}..."
+git checkout -b "$RELEASE_BRANCH"
+
+git add Cargo.toml Cargo.lock CHANGELOG.md
+git commit -m "Prepare v${VERSION} release"
+
+echo "==> Pushing branch..."
+git push -u origin "$RELEASE_BRANCH" 2>&1
+
+echo "==> Creating PR..."
+PR_URL=$(gh pr create \
+    --title "Release v${VERSION}" \
+    --body "## Summary
+- Version bump to ${VERSION}
+- See CHANGELOG.md for details
+
+Merging this PR will automatically create the \`v${VERSION}\` tag and trigger the release workflow.")
+
+echo ""
+echo "================================================"
+echo "  Release PR created: ${PR_URL}"
+echo "================================================"
+echo ""
+echo "Next steps:"
+echo "  1. Review and merge the PR"
+echo "  2. Tag is created automatically -> release workflow runs"
+echo ""


### PR DESCRIPTION
## Summary
- Add `scripts/release.sh` for one-command release preparation
- Add `.github/workflows/auto-tag.yml` to auto-create git tags when release PRs are merged
- Update `PUBLISHING.md` with simplified instructions

## New release flow
```
./scripts/release.sh 0.2.0   # version bump, CHANGELOG, PR creation
-> Merge PR                   # auto-tag workflow creates git tag
-> release.yml                # cargo-dist builds & publishes automatically
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)