### PR TITLE
Add MySQL dialect support

### DIFF
--- a/crates/sqlsurge-core/src/dialect/mod.rs
+++ b/crates/sqlsurge-core/src/dialect/mod.rs
@@ -1,6 +1,6 @@
 //! SQL dialect support
 
-use sqlparser::dialect::{Dialect, PostgreSqlDialect};
+use sqlparser::dialect::{Dialect, MySqlDialect, PostgreSqlDialect};
 use std::str::FromStr;
 
 /// Supported SQL dialects
@@ -8,6 +8,7 @@ use std::str::FromStr;
 pub enum SqlDialect {
     #[default]
     PostgreSQL,
+    MySQL,
 }
 
 impl SqlDialect {
@@ -15,6 +16,7 @@ impl SqlDialect {
     pub fn parser_dialect(&self) -> Box<dyn Dialect> {
         match self {
             SqlDialect::PostgreSQL => Box::new(PostgreSqlDialect {}),
+            SqlDialect::MySQL => Box::new(MySqlDialect {}),
         }
     }
 
@@ -22,6 +24,7 @@ impl SqlDialect {
     pub fn default_schema(&self) -> &'static str {
         match self {
             SqlDialect::PostgreSQL => "public",
+            SqlDialect::MySQL => "",
         }
     }
 }
@@ -32,16 +35,13 @@ impl FromStr for SqlDialect {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s.to_lowercase().as_str() {
             "postgresql" | "postgres" | "pg" => Ok(SqlDialect::PostgreSQL),
-            "mysql" => Err(
-                "MySQL dialect is not yet supported. Currently only PostgreSQL is supported."
-                    .to_string(),
-            ),
+            "mysql" | "mysql8" => Ok(SqlDialect::MySQL),
             "sqlite" => Err(
-                "SQLite dialect is not yet supported. Currently only PostgreSQL is supported."
+                "SQLite dialect is not yet supported. Supported dialects: postgresql, mysql."
                     .to_string(),
             ),
             _ => Err(format!(
-                "Unknown dialect: '{}'. Currently only PostgreSQL is supported.",
+                "Unknown dialect: '{}'. Supported dialects: postgresql, mysql.",
                 s
             )),
         }
@@ -52,6 +52,7 @@ impl std::fmt::Display for SqlDialect {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             SqlDialect::PostgreSQL => write!(f, "postgresql"),
+            SqlDialect::MySQL => write!(f, "mysql"),
         }
     }
 }

--- a/crates/sqlsurge-core/src/schema/builder.rs
+++ b/crates/sqlsurge-core/src/schema/builder.rs
@@ -5,6 +5,7 @@ use sqlparser::ast::{
     UserDefinedTypeRepresentation,
 };
 use sqlparser::parser::Parser;
+use sqlparser::tokenizer::Token;
 
 use crate::dialect::SqlDialect;
 use crate::error::{Diagnostic, DiagnosticKind};
@@ -494,6 +495,15 @@ impl SchemaBuilder {
                     };
                     col.identity = Some(kind);
                     col.nullable = false; // IDENTITY columns are implicitly NOT NULL
+                }
+            }
+            ColumnOption::DialectSpecific(tokens) => {
+                // MySQL AUTO_INCREMENT
+                if tokens
+                    .iter()
+                    .any(|t| matches!(t, Token::Word(w) if w.value == "AUTO_INCREMENT"))
+                {
+                    col.nullable = false; // AUTO_INCREMENT implies NOT NULL
                 }
             }
             _ => {}

--- a/tests/fixtures/real-world/THIRD-PARTY-LICENSES.md
+++ b/tests/fixtures/real-world/THIRD-PARTY-LICENSES.md
@@ -55,6 +55,49 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+## Chinook Database (MySQL version)
+
+- Source: https://github.com/lerocha/chinook-database
+- Files: `chinook-mysql-schema.sql`, `chinook-mysql-queries.sql`, `chinook-mysql-invalid-queries.sql`
+- License: MIT License
+
+Copyright (c) 2008-2024 Luis Rocha
+
+(Same MIT License as above)
+
+## Sakila Database (MySQL version)
+
+- Source: https://github.com/jOOQ/sakila
+- Files: `sakila-mysql-schema.sql`, `sakila-mysql-queries.sql`, `sakila-mysql-invalid-queries.sql`
+- License: BSD 2-Clause "Simplified" License
+
+Copyright (c) 2017, Data Geekery GmbH.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Original Sakila database is Copyright (c) MySQL AB and is licensed under the
+New BSD License. See https://dev.mysql.com/doc/sakila/en/ for details.
+
 ## Northwind (PostgreSQL port)
 
 - Source: https://github.com/pthom/northwind_psql

--- a/tests/fixtures/real-world/chinook-mysql-invalid-queries.sql
+++ b/tests/fixtures/real-world/chinook-mysql-invalid-queries.sql
@@ -1,0 +1,43 @@
+-- Invalid queries against the Chinook MySQL schema (error detection tests)
+
+-- E0001: Table not found
+SELECT * FROM Song;
+
+-- E0002: Column not found (typo in Artist)
+SELECT ArtistId, Nme FROM Artist;
+
+-- E0002: Column not found (wrong column)
+SELECT TrackId, SongName FROM Track;
+
+-- E0001: Table not found in JOIN
+SELECT al.Title, l.Name
+FROM Album al
+INNER JOIN Label l ON al.LabelId = l.LabelId;
+
+-- E0002: Column not found in JOIN condition
+SELECT t.Name, al.Title
+FROM Track t
+INNER JOIN Album al ON t.album_id = al.AlbumId;
+
+-- E0002: Column not found in WHERE
+SELECT FirstName, LastName FROM Customer WHERE Age > 30;
+
+-- E0002: Column not found in aggregate
+SELECT GenreId, AVG(Duration) FROM Track GROUP BY GenreId;
+
+-- E0005: Column count mismatch in INSERT
+INSERT INTO Artist (Name) VALUES ('Artist1', 'Artist2');
+
+-- E0002: Column not found in INSERT
+INSERT INTO Track (Name, AlbumId, MediaTypeId, GenreId, Length, UnitPrice)
+VALUES ('Test', 1, 1, 1, 300000, 0.99);
+
+-- E0001: Table not found in subquery
+SELECT Name FROM Artist
+WHERE ArtistId IN (SELECT ArtistId FROM Record);
+
+-- E0001: Table not found in DELETE
+DELETE FROM Songs WHERE TrackId = 1;
+
+-- E0002: Column not found in UPDATE
+UPDATE Album SET AlbumTitle = 'New Title' WHERE AlbumId = 1;

--- a/tests/fixtures/real-world/chinook-mysql-queries.sql
+++ b/tests/fixtures/real-world/chinook-mysql-queries.sql
@@ -1,0 +1,256 @@
+-- Valid queries against the Chinook MySQL schema
+-- Tests: SELECT, JOIN, subquery, CTE, aggregate, INSERT, UPDATE, DELETE
+
+-- 1. Basic SELECT
+SELECT ArtistId, Name FROM Artist;
+
+-- 2. SELECT with WHERE
+SELECT TrackId, Name, UnitPrice FROM Track WHERE UnitPrice > 0.99;
+
+-- 3. Album with Artist JOIN
+SELECT al.Title, ar.Name AS ArtistName
+FROM Album al
+INNER JOIN Artist ar ON al.ArtistId = ar.ArtistId;
+
+-- 4. Track with Album and Artist
+SELECT t.Name AS TrackName, al.Title AS AlbumTitle, ar.Name AS ArtistName
+FROM Track t
+INNER JOIN Album al ON t.AlbumId = al.AlbumId
+INNER JOIN Artist ar ON al.ArtistId = ar.ArtistId;
+
+-- 5. Track with Genre and MediaType
+SELECT t.Name, g.Name AS Genre, mt.Name AS MediaType
+FROM Track t
+INNER JOIN Genre g ON t.GenreId = g.GenreId
+INNER JOIN MediaType mt ON t.MediaTypeId = mt.MediaTypeId;
+
+-- 6. LEFT JOIN (artists without albums)
+SELECT ar.Name, al.Title
+FROM Artist ar
+LEFT JOIN Album al ON ar.ArtistId = al.ArtistId;
+
+-- 7. Customer with support rep (Employee self-ref)
+SELECT c.FirstName, c.LastName, c.Email,
+       e.FirstName AS RepFirstName, e.LastName AS RepLastName
+FROM Customer c
+LEFT JOIN Employee e ON c.SupportRepId = e.EmployeeId;
+
+-- 8. Employee hierarchy (self-join)
+SELECT e.FirstName AS Employee, e.Title,
+       m.FirstName AS Manager, m.Title AS ManagerTitle
+FROM Employee e
+LEFT JOIN Employee m ON e.ReportsTo = m.EmployeeId;
+
+-- 9. Invoice with Customer
+SELECT i.InvoiceId, i.InvoiceDate, i.Total,
+       c.FirstName, c.LastName, c.Email
+FROM Invoice i
+INNER JOIN Customer c ON i.CustomerId = c.CustomerId;
+
+-- 10. InvoiceLine with Track details
+SELECT il.InvoiceLineId, il.Quantity, il.UnitPrice,
+       t.Name AS TrackName, al.Title AS AlbumTitle
+FROM InvoiceLine il
+INNER JOIN Track t ON il.TrackId = t.TrackId
+INNER JOIN Album al ON t.AlbumId = al.AlbumId;
+
+-- 11. Playlist contents
+SELECT p.Name AS PlaylistName, t.Name AS TrackName
+FROM Playlist p
+INNER JOIN PlaylistTrack pt ON p.PlaylistId = pt.PlaylistId
+INNER JOIN Track t ON pt.TrackId = t.TrackId;
+
+-- 12. Aggregate: tracks per genre
+SELECT g.Name AS Genre, COUNT(t.TrackId) AS TrackCount
+FROM Genre g
+INNER JOIN Track t ON g.GenreId = t.GenreId
+GROUP BY g.Name;
+
+-- 13. Aggregate: revenue per customer
+SELECT c.FirstName, c.LastName, SUM(i.Total) AS TotalSpent
+FROM Customer c
+INNER JOIN Invoice i ON c.CustomerId = i.CustomerId
+GROUP BY c.CustomerId, c.FirstName, c.LastName;
+
+-- 14. Aggregate: albums per artist with HAVING
+SELECT ar.Name, COUNT(al.AlbumId) AS AlbumCount
+FROM Artist ar
+INNER JOIN Album al ON ar.ArtistId = al.ArtistId
+GROUP BY ar.ArtistId, ar.Name
+HAVING COUNT(al.AlbumId) > 5;
+
+-- 15. Aggregate: total duration per album (milliseconds)
+SELECT al.Title, SUM(t.Milliseconds) AS TotalDuration, COUNT(t.TrackId) AS TrackCount
+FROM Album al
+INNER JOIN Track t ON al.AlbumId = t.AlbumId
+GROUP BY al.AlbumId, al.Title;
+
+-- 16. Subquery in WHERE (IN)
+SELECT Name FROM Artist
+WHERE ArtistId IN (
+    SELECT al.ArtistId FROM Album al WHERE al.AlbumId IN (
+        SELECT t.AlbumId FROM Track t WHERE t.GenreId = 1
+    )
+);
+
+-- 17. Subquery in WHERE (EXISTS)
+SELECT c.FirstName, c.LastName
+FROM Customer c
+WHERE EXISTS (
+    SELECT 1 FROM Invoice i WHERE i.CustomerId = c.CustomerId AND i.Total > 10
+);
+
+-- 18. Correlated subquery (scalar)
+SELECT ar.Name,
+    (SELECT COUNT(*) FROM Album al WHERE al.ArtistId = ar.ArtistId) AS AlbumCount
+FROM Artist ar;
+
+-- 19. Subquery in FROM (derived table)
+SELECT sub.Genre, sub.AvgPrice
+FROM (
+    SELECT g.Name AS Genre, AVG(t.UnitPrice) AS AvgPrice
+    FROM Genre g
+    INNER JOIN Track t ON g.GenreId = t.GenreId
+    GROUP BY g.Name
+) AS sub
+WHERE sub.AvgPrice > 1.00;
+
+-- 20. CTE: top selling tracks
+WITH track_sales AS (
+    SELECT t.TrackId, t.Name, SUM(il.Quantity) AS TotalSold
+    FROM Track t
+    INNER JOIN InvoiceLine il ON t.TrackId = il.TrackId
+    GROUP BY t.TrackId, t.Name
+)
+SELECT Name, TotalSold
+FROM track_sales
+WHERE TotalSold > 2;
+
+-- 21. CTE: customer invoice summary
+WITH customer_summary AS (
+    SELECT c.CustomerId, c.FirstName, c.LastName,
+           COUNT(i.InvoiceId) AS InvoiceCount,
+           SUM(i.Total) AS TotalSpent
+    FROM Customer c
+    INNER JOIN Invoice i ON c.CustomerId = i.CustomerId
+    GROUP BY c.CustomerId, c.FirstName, c.LastName
+)
+SELECT FirstName, LastName, InvoiceCount, TotalSpent
+FROM customer_summary;
+
+-- 22. Multiple CTEs
+WITH genre_tracks AS (
+    SELECT g.GenreId, g.Name AS GenreName, COUNT(t.TrackId) AS TrackCount
+    FROM Genre g
+    INNER JOIN Track t ON g.GenreId = t.GenreId
+    GROUP BY g.GenreId, g.Name
+),
+genre_revenue AS (
+    SELECT g.GenreId, SUM(il.UnitPrice * il.Quantity) AS Revenue
+    FROM Genre g
+    INNER JOIN Track t ON g.GenreId = t.GenreId
+    INNER JOIN InvoiceLine il ON t.TrackId = il.TrackId
+    GROUP BY g.GenreId
+)
+SELECT gt.GenreName, gt.TrackCount, gr.Revenue
+FROM genre_tracks gt
+INNER JOIN genre_revenue gr ON gt.GenreId = gr.GenreId;
+
+-- 23. INSERT
+INSERT INTO Artist (Name) VALUES ('New Artist');
+
+-- 24. INSERT with columns
+INSERT INTO Album (Title, ArtistId) VALUES ('New Album', 1);
+
+-- 25. INSERT with subquery
+INSERT INTO PlaylistTrack (PlaylistId, TrackId)
+SELECT 1, TrackId FROM Track WHERE GenreId = 1;
+
+-- 26. UPDATE
+UPDATE Track SET UnitPrice = 1.29 WHERE TrackId = 1;
+
+-- 27. UPDATE with subquery
+UPDATE Customer SET SupportRepId = 3
+WHERE CustomerId IN (
+    SELECT i.CustomerId FROM Invoice i WHERE i.Total > 20
+);
+
+-- 28. DELETE
+DELETE FROM InvoiceLine WHERE InvoiceLineId = 1;
+
+-- 29. DELETE with subquery
+DELETE FROM PlaylistTrack
+WHERE TrackId IN (
+    SELECT t.TrackId FROM Track t WHERE t.Bytes IS NULL
+);
+
+-- 30. DISTINCT
+SELECT DISTINCT Country FROM Customer;
+
+-- 31. ORDER BY with alias
+SELECT ar.Name, COUNT(al.AlbumId) AS NumAlbums
+FROM Artist ar
+INNER JOIN Album al ON ar.ArtistId = al.ArtistId
+GROUP BY ar.ArtistId, ar.Name
+ORDER BY NumAlbums DESC;
+
+-- 32. UNION: all people names
+SELECT c.FirstName, c.LastName, 'Customer' AS Type FROM Customer c
+UNION
+SELECT e.FirstName, e.LastName, 'Employee' AS Type FROM Employee e;
+
+-- 33. NULL handling
+SELECT TrackId, Name, Composer FROM Track WHERE Composer IS NOT NULL;
+
+-- 34. BETWEEN
+SELECT InvoiceId, Total FROM Invoice WHERE Total BETWEEN 5.00 AND 15.00;
+
+-- 35. LIKE pattern
+SELECT FirstName, LastName FROM Customer WHERE LastName LIKE 'M%';
+
+-- 36. Full invoice detail chain (5 tables)
+SELECT i.InvoiceId, i.InvoiceDate, c.FirstName, c.LastName,
+       t.Name AS TrackName, al.Title AS AlbumTitle,
+       il.Quantity, il.UnitPrice
+FROM Invoice i
+INNER JOIN Customer c ON i.CustomerId = c.CustomerId
+INNER JOIN InvoiceLine il ON i.InvoiceId = il.InvoiceId
+INNER JOIN Track t ON il.TrackId = t.TrackId
+INNER JOIN Album al ON t.AlbumId = al.AlbumId;
+
+-- 37. Cross join
+SELECT g.Name AS Genre, mt.Name AS MediaType
+FROM Genre g
+CROSS JOIN MediaType mt;
+
+-- 38. Nested subquery in SELECT
+SELECT ar.Name,
+    (SELECT COUNT(DISTINCT g.GenreId)
+     FROM Album al
+     INNER JOIN Track t ON al.AlbumId = t.AlbumId
+     INNER JOIN Genre g ON t.GenreId = g.GenreId
+     WHERE al.ArtistId = ar.ArtistId) AS GenreCount
+FROM Artist ar;
+
+-- 39. Complex CTE: employee sales performance
+WITH employee_sales AS (
+    SELECT e.EmployeeId, e.FirstName, e.LastName,
+           SUM(i.Total) AS TotalSales
+    FROM Employee e
+    INNER JOIN Customer c ON e.EmployeeId = c.SupportRepId
+    INNER JOIN Invoice i ON c.CustomerId = i.CustomerId
+    GROUP BY e.EmployeeId, e.FirstName, e.LastName
+)
+SELECT FirstName, LastName, TotalSales
+FROM employee_sales;
+
+-- 40. Derived table join
+SELECT ar.Name, album_stats.AlbumCount, album_stats.TotalTracks
+FROM Artist ar
+INNER JOIN (
+    SELECT al.ArtistId, COUNT(DISTINCT al.AlbumId) AS AlbumCount,
+           COUNT(t.TrackId) AS TotalTracks
+    FROM Album al
+    LEFT JOIN Track t ON al.AlbumId = t.AlbumId
+    GROUP BY al.ArtistId
+) AS album_stats ON ar.ArtistId = album_stats.ArtistId;

--- a/tests/fixtures/real-world/chinook-mysql-schema.sql
+++ b/tests/fixtures/real-world/chinook-mysql-schema.sql
@@ -1,0 +1,123 @@
+-- Chinook Database Schema (MySQL version with AUTO_INCREMENT PKs)
+-- Source: https://github.com/lerocha/chinook-database
+-- License: MIT License
+-- Original author: Luis Rocha
+
+CREATE TABLE Artist (
+    ArtistId INT NOT NULL AUTO_INCREMENT,
+    Name NVARCHAR(120),
+    CONSTRAINT PK_Artist PRIMARY KEY (ArtistId)
+);
+
+CREATE TABLE Album (
+    AlbumId INT NOT NULL AUTO_INCREMENT,
+    Title NVARCHAR(160) NOT NULL,
+    ArtistId INT NOT NULL,
+    CONSTRAINT PK_Album PRIMARY KEY (AlbumId),
+    CONSTRAINT FK_AlbumArtistId FOREIGN KEY (ArtistId) REFERENCES Artist (ArtistId)
+);
+
+CREATE TABLE Employee (
+    EmployeeId INT NOT NULL AUTO_INCREMENT,
+    LastName NVARCHAR(20) NOT NULL,
+    FirstName NVARCHAR(20) NOT NULL,
+    Title NVARCHAR(30),
+    ReportsTo INT,
+    BirthDate DATETIME,
+    HireDate DATETIME,
+    Address NVARCHAR(70),
+    City NVARCHAR(40),
+    State NVARCHAR(40),
+    Country NVARCHAR(40),
+    PostalCode NVARCHAR(10),
+    Phone NVARCHAR(24),
+    Fax NVARCHAR(24),
+    Email NVARCHAR(60),
+    CONSTRAINT PK_Employee PRIMARY KEY (EmployeeId),
+    CONSTRAINT FK_EmployeeReportsTo FOREIGN KEY (ReportsTo) REFERENCES Employee (EmployeeId)
+);
+
+CREATE TABLE Customer (
+    CustomerId INT NOT NULL AUTO_INCREMENT,
+    FirstName NVARCHAR(40) NOT NULL,
+    LastName NVARCHAR(20) NOT NULL,
+    Company NVARCHAR(80),
+    Address NVARCHAR(70),
+    City NVARCHAR(40),
+    State NVARCHAR(40),
+    Country NVARCHAR(40),
+    PostalCode NVARCHAR(10),
+    Phone NVARCHAR(24),
+    Fax NVARCHAR(24),
+    Email NVARCHAR(60) NOT NULL,
+    SupportRepId INT,
+    CONSTRAINT PK_Customer PRIMARY KEY (CustomerId),
+    CONSTRAINT FK_CustomerSupportRepId FOREIGN KEY (SupportRepId) REFERENCES Employee (EmployeeId)
+);
+
+CREATE TABLE Genre (
+    GenreId INT NOT NULL AUTO_INCREMENT,
+    Name NVARCHAR(120),
+    CONSTRAINT PK_Genre PRIMARY KEY (GenreId)
+);
+
+CREATE TABLE MediaType (
+    MediaTypeId INT NOT NULL AUTO_INCREMENT,
+    Name NVARCHAR(120),
+    CONSTRAINT PK_MediaType PRIMARY KEY (MediaTypeId)
+);
+
+CREATE TABLE Track (
+    TrackId INT NOT NULL AUTO_INCREMENT,
+    Name NVARCHAR(200) NOT NULL,
+    AlbumId INT,
+    MediaTypeId INT NOT NULL,
+    GenreId INT,
+    Composer NVARCHAR(220),
+    Milliseconds INT NOT NULL,
+    Bytes INT,
+    UnitPrice NUMERIC(10,2) NOT NULL,
+    CONSTRAINT PK_Track PRIMARY KEY (TrackId),
+    CONSTRAINT FK_TrackAlbumId FOREIGN KEY (AlbumId) REFERENCES Album (AlbumId),
+    CONSTRAINT FK_TrackMediaTypeId FOREIGN KEY (MediaTypeId) REFERENCES MediaType (MediaTypeId),
+    CONSTRAINT FK_TrackGenreId FOREIGN KEY (GenreId) REFERENCES Genre (GenreId)
+);
+
+CREATE TABLE Invoice (
+    InvoiceId INT NOT NULL AUTO_INCREMENT,
+    CustomerId INT NOT NULL,
+    InvoiceDate DATETIME NOT NULL,
+    BillingAddress NVARCHAR(70),
+    BillingCity NVARCHAR(40),
+    BillingState NVARCHAR(40),
+    BillingCountry NVARCHAR(40),
+    BillingPostalCode NVARCHAR(10),
+    Total NUMERIC(10,2) NOT NULL,
+    CONSTRAINT PK_Invoice PRIMARY KEY (InvoiceId),
+    CONSTRAINT FK_InvoiceCustomerId FOREIGN KEY (CustomerId) REFERENCES Customer (CustomerId)
+);
+
+CREATE TABLE InvoiceLine (
+    InvoiceLineId INT NOT NULL AUTO_INCREMENT,
+    InvoiceId INT NOT NULL,
+    TrackId INT NOT NULL,
+    UnitPrice NUMERIC(10,2) NOT NULL,
+    Quantity INT NOT NULL,
+    CONSTRAINT PK_InvoiceLine PRIMARY KEY (InvoiceLineId),
+    CONSTRAINT FK_InvoiceLineInvoiceId FOREIGN KEY (InvoiceId) REFERENCES Invoice (InvoiceId),
+    CONSTRAINT FK_InvoiceLineTrackId FOREIGN KEY (TrackId) REFERENCES Track (TrackId)
+);
+
+CREATE TABLE Playlist (
+    PlaylistId INT NOT NULL AUTO_INCREMENT,
+    Name NVARCHAR(120),
+    CONSTRAINT PK_Playlist PRIMARY KEY (PlaylistId)
+);
+
+CREATE TABLE PlaylistTrack (
+    PlaylistId INT NOT NULL,
+    TrackId INT NOT NULL,
+    CONSTRAINT PK_PlaylistTrack PRIMARY KEY (PlaylistId, TrackId),
+    CONSTRAINT FK_PlaylistTrackPlaylistId FOREIGN KEY (PlaylistId) REFERENCES Playlist (PlaylistId),
+    CONSTRAINT FK_PlaylistTrackTrackId FOREIGN KEY (TrackId) REFERENCES Track (TrackId)
+);

--- a/tests/fixtures/real-world/sakila-mysql-invalid-queries.sql
+++ b/tests/fixtures/real-world/sakila-mysql-invalid-queries.sql
@@ -1,0 +1,45 @@
+-- Invalid queries against the Sakila MySQL schema (error detection tests)
+
+-- E0001: Table not found
+SELECT * FROM movies;
+
+-- E0002: Column not found (typo)
+SELECT first_name, lst_name FROM actor;
+
+-- E0002: Column not found
+SELECT titl FROM film;
+
+-- E0001: Table not found in JOIN
+SELECT f.title, d.name
+FROM film f
+INNER JOIN director d ON f.director_id = d.director_id;
+
+-- E0002: Column not found in WHERE
+SELECT film_id, title FROM film WHERE genre = 'Action';
+
+-- E0002: Column not found in JOIN condition
+SELECT f.title, a.first_name
+FROM film f
+INNER JOIN film_actor fa ON f.film_id = fa.film_id
+INNER JOIN actor a ON fa.actor_id = a.id;
+
+-- E0002: Column not found in aggregate
+SELECT rating, AVG(duration) AS avg_len FROM film GROUP BY rating;
+
+-- E0002: Column not found (table has 'amount', not 'total')
+SELECT customer_id, SUM(total) FROM payment GROUP BY customer_id;
+
+-- E0002: Column not found in subquery
+SELECT first_name, last_name FROM customer
+WHERE customer_id IN (SELECT cust_id FROM rental);
+
+-- E0005: Column count mismatch in INSERT
+INSERT INTO actor (first_name, last_name)
+VALUES ('JOHN', 'DOE', '2024-01-01');
+
+-- E0002: Column not found in INSERT
+INSERT INTO film (title, description, language_id, genre)
+VALUES ('Test Film', 'Description', 1, 'Action');
+
+-- E0001: Table not found in INSERT
+INSERT INTO directors (first_name, last_name) VALUES ('Steven', 'Spielberg');

--- a/tests/fixtures/real-world/sakila-mysql-queries.sql
+++ b/tests/fixtures/real-world/sakila-mysql-queries.sql
@@ -1,0 +1,277 @@
+-- Valid queries against the Sakila MySQL schema
+-- Tests: SELECT, JOIN, subquery, CTE, aggregate, INSERT, UPDATE, DELETE
+
+-- 1. Basic SELECT
+SELECT actor_id, first_name, last_name FROM actor;
+
+-- 2. SELECT with WHERE
+SELECT film_id, title, description, rental_rate
+FROM film
+WHERE rental_rate > 2.99;
+
+-- 3. INNER JOIN two tables
+SELECT f.title, l.name AS language_name
+FROM film f
+INNER JOIN language l ON f.language_id = l.language_id;
+
+-- 4. Multi-table JOIN (film -> actor through junction)
+SELECT a.first_name, a.last_name, f.title
+FROM actor a
+INNER JOIN film_actor fa ON a.actor_id = fa.actor_id
+INNER JOIN film f ON fa.film_id = f.film_id;
+
+-- 5. LEFT JOIN (films without actors)
+SELECT f.title, fa.actor_id
+FROM film f
+LEFT JOIN film_actor fa ON f.film_id = fa.film_id;
+
+-- 6. Three-way JOIN with category
+SELECT f.title, c.name AS category_name
+FROM film f
+INNER JOIN film_category fc ON f.film_id = fc.film_id
+INNER JOIN category c ON fc.category_id = c.category_id;
+
+-- 7. Customer with address chain (4 tables)
+SELECT cu.first_name, cu.last_name, cu.email,
+       a.address, ci.city, co.country
+FROM customer cu
+INNER JOIN address a ON cu.address_id = a.address_id
+INNER JOIN city ci ON a.city_id = ci.city_id
+INNER JOIN country co ON ci.country_id = co.country_id;
+
+-- 8. Aggregate: films per category
+SELECT c.name AS category, COUNT(fc.film_id) AS film_count
+FROM category c
+INNER JOIN film_category fc ON c.category_id = fc.category_id
+GROUP BY c.name;
+
+-- 9. Aggregate: total revenue per store
+SELECT s.store_id, SUM(p.amount) AS total_revenue
+FROM store s
+INNER JOIN staff st ON s.store_id = st.store_id
+INNER JOIN payment p ON st.staff_id = p.staff_id
+GROUP BY s.store_id;
+
+-- 10. Aggregate: average rental duration per rating
+SELECT rating, AVG(rental_duration) AS avg_duration
+FROM film
+GROUP BY rating;
+
+-- 11. Aggregate with HAVING
+SELECT a.first_name, a.last_name, COUNT(fa.film_id) AS film_count
+FROM actor a
+INNER JOIN film_actor fa ON a.actor_id = fa.actor_id
+GROUP BY a.actor_id, a.first_name, a.last_name
+HAVING COUNT(fa.film_id) > 20;
+
+-- 12. Subquery in WHERE (IN)
+SELECT first_name, last_name
+FROM customer
+WHERE address_id IN (
+    SELECT a.address_id FROM address a WHERE a.city_id IN (
+        SELECT ci.city_id FROM city ci WHERE ci.country_id = 1
+    )
+);
+
+-- 13. Subquery in WHERE (EXISTS)
+SELECT f.title
+FROM film f
+WHERE EXISTS (
+    SELECT 1 FROM inventory i WHERE i.film_id = f.film_id
+);
+
+-- 14. Correlated subquery
+SELECT c.first_name, c.last_name,
+    (SELECT COUNT(*) FROM rental r WHERE r.customer_id = c.customer_id) AS rental_count
+FROM customer c;
+
+-- 15. Subquery in FROM (derived table)
+SELECT sub.category, sub.film_count
+FROM (
+    SELECT c.name AS category, COUNT(fc.film_id) AS film_count
+    FROM category c
+    INNER JOIN film_category fc ON c.category_id = fc.category_id
+    GROUP BY c.name
+) AS sub
+WHERE sub.film_count > 50;
+
+-- 16. CTE: top customers by payment
+WITH customer_totals AS (
+    SELECT c.customer_id, c.first_name, c.last_name,
+           SUM(p.amount) AS total_spent
+    FROM customer c
+    INNER JOIN payment p ON c.customer_id = p.customer_id
+    GROUP BY c.customer_id, c.first_name, c.last_name
+)
+SELECT first_name, last_name, total_spent
+FROM customer_totals
+WHERE total_spent > 100;
+
+-- 17. CTE: film inventory per store
+WITH film_inventory AS (
+    SELECT f.title, s.store_id, COUNT(i.inventory_id) AS copies
+    FROM film f
+    INNER JOIN inventory i ON f.film_id = i.film_id
+    INNER JOIN store s ON i.store_id = s.store_id
+    GROUP BY f.title, s.store_id
+)
+SELECT title, store_id, copies
+FROM film_inventory
+WHERE copies > 3;
+
+-- 18. Multiple CTEs
+WITH active_customers AS (
+    SELECT customer_id, first_name, last_name
+    FROM customer
+    WHERE active = TRUE
+),
+customer_rentals AS (
+    SELECT ac.customer_id, ac.first_name, ac.last_name,
+           COUNT(r.rental_id) AS rental_count
+    FROM active_customers ac
+    INNER JOIN rental r ON ac.customer_id = r.customer_id
+    GROUP BY ac.customer_id, ac.first_name, ac.last_name
+)
+SELECT first_name, last_name, rental_count
+FROM customer_rentals;
+
+-- 19. INSERT into actor
+INSERT INTO actor (first_name, last_name)
+VALUES ('JOHN', 'DOE');
+
+-- 20. INSERT into rental
+INSERT INTO rental (rental_date, inventory_id, customer_id, staff_id)
+VALUES ('2024-01-01 10:00:00', 1, 1, 1);
+
+-- 21. INSERT with subquery
+INSERT INTO film_text (film_id, title, description)
+SELECT film_id, title, description FROM film WHERE film_id = 1;
+
+-- 22. UPDATE single table
+UPDATE film SET rental_rate = 3.99
+WHERE film_id = 1;
+
+-- 23. UPDATE with subquery in WHERE
+UPDATE customer SET active = FALSE
+WHERE customer_id IN (
+    SELECT r.customer_id FROM rental r
+    WHERE r.return_date IS NULL
+);
+
+-- 24. DELETE
+DELETE FROM payment WHERE payment_id = 1;
+
+-- 25. DELETE with subquery
+DELETE FROM film_actor
+WHERE film_id IN (
+    SELECT f.film_id FROM film f WHERE f.rating = 'NC-17'
+);
+
+-- 26. Self-join on address/city hierarchy
+SELECT ci.city, co.country
+FROM city ci
+INNER JOIN country co ON ci.country_id = co.country_id;
+
+-- 27. ENUM column in WHERE
+SELECT film_id, title, rating
+FROM film
+WHERE rating = 'PG-13';
+
+-- 28. ORDER BY with alias
+SELECT c.name AS category, COUNT(fc.film_id) AS total_films
+FROM category c
+INNER JOIN film_category fc ON c.category_id = fc.category_id
+GROUP BY c.name
+ORDER BY total_films DESC;
+
+-- 29. NULL handling
+SELECT film_id, title, original_language_id
+FROM film
+WHERE original_language_id IS NULL;
+
+-- 30. BETWEEN and comparison
+SELECT title, rental_rate, replacement_cost
+FROM film
+WHERE rental_rate BETWEEN 2.99 AND 4.99
+  AND replacement_cost < 20.00;
+
+-- 31. LIKE pattern
+SELECT first_name, last_name
+FROM actor
+WHERE last_name LIKE 'S%';
+
+-- 32. DISTINCT
+SELECT DISTINCT rating FROM film;
+
+-- 33. UNION
+SELECT a.first_name, a.last_name, 'actor' AS person_type FROM actor a
+UNION
+SELECT c.first_name, c.last_name, 'customer' AS person_type FROM customer c;
+
+-- 34. Rental + payment combined analysis
+SELECT r.rental_id, r.rental_date, p.amount, p.payment_date,
+       c.first_name, c.last_name
+FROM rental r
+INNER JOIN payment p ON r.rental_id = p.rental_id
+INNER JOIN customer c ON r.customer_id = c.customer_id;
+
+-- 35. Staff and store with address
+SELECT st.first_name, st.last_name, st.email,
+       s.store_id, a.address, ci.city
+FROM staff st
+INNER JOIN store s ON st.store_id = s.store_id
+INNER JOIN address a ON st.address_id = a.address_id
+INNER JOIN city ci ON a.city_id = ci.city_id;
+
+-- 36. Complex aggregate: most popular films
+WITH rental_counts AS (
+    SELECT i.film_id, COUNT(r.rental_id) AS times_rented
+    FROM inventory i
+    INNER JOIN rental r ON i.inventory_id = r.inventory_id
+    GROUP BY i.film_id
+)
+SELECT f.title, rc.times_rented
+FROM film f
+INNER JOIN rental_counts rc ON f.film_id = rc.film_id
+ORDER BY rc.times_rented DESC;
+
+-- 37. Cross join (all film-language combinations)
+SELECT f.title, l.name AS lang
+FROM film f
+CROSS JOIN language l;
+
+-- 38. Inventory availability check
+SELECT f.title, s.store_id,
+       COUNT(i.inventory_id) AS in_stock
+FROM film f
+INNER JOIN inventory i ON f.film_id = i.film_id
+INNER JOIN store s ON i.store_id = s.store_id
+LEFT JOIN rental r ON i.inventory_id = r.inventory_id AND r.return_date IS NULL
+WHERE r.rental_id IS NULL
+GROUP BY f.title, s.store_id;
+
+-- 39. Multiple aggregates
+SELECT c.name AS category,
+       COUNT(f.film_id) AS num_films,
+       AVG(f.rental_rate) AS avg_rate,
+       SUM(f.replacement_cost) AS total_cost,
+       MIN(f.length) AS shortest,
+       MAX(f.length) AS longest
+FROM category c
+INNER JOIN film_category fc ON c.category_id = fc.category_id
+INNER JOIN film f ON fc.film_id = f.film_id
+GROUP BY c.name;
+
+-- 40. Nested derived table
+SELECT top_cats.category, top_cats.avg_rate
+FROM (
+    SELECT sub.category, sub.avg_rate
+    FROM (
+        SELECT c.name AS category, AVG(f.rental_rate) AS avg_rate
+        FROM category c
+        INNER JOIN film_category fc ON c.category_id = fc.category_id
+        INNER JOIN film f ON fc.film_id = f.film_id
+        GROUP BY c.name
+    ) AS sub
+    WHERE sub.avg_rate > 3.00
+) AS top_cats;

--- a/tests/fixtures/real-world/sakila-mysql-schema.sql
+++ b/tests/fixtures/real-world/sakila-mysql-schema.sql
@@ -1,0 +1,202 @@
+-- Sakila Sample Database Schema (MySQL version)
+-- Source: https://github.com/jOOQ/sakila
+-- License: BSD-2-Clause (New BSD License)
+-- Original author: Mike Hillyer (MySQL AB)
+
+-- Note: Tables are ordered to satisfy foreign key dependencies.
+-- Some MySQL-specific features (SET type, FULLTEXT, BINARY) may be
+-- skipped by sqlsurge's resilient parser.
+
+CREATE TABLE actor (
+  actor_id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  first_name VARCHAR(45) NOT NULL,
+  last_name VARCHAR(45) NOT NULL,
+  last_update TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (actor_id),
+  KEY idx_actor_last_name (last_name)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE country (
+  country_id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  country VARCHAR(50) NOT NULL,
+  last_update TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (country_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE city (
+  city_id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  city VARCHAR(50) NOT NULL,
+  country_id INT UNSIGNED NOT NULL,
+  last_update TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (city_id),
+  KEY idx_fk_country_id (country_id),
+  CONSTRAINT fk_city_country FOREIGN KEY (country_id) REFERENCES country (country_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE address (
+  address_id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  address VARCHAR(50) NOT NULL,
+  address2 VARCHAR(50) DEFAULT NULL,
+  district VARCHAR(20) NOT NULL,
+  city_id INT UNSIGNED NOT NULL,
+  postal_code VARCHAR(10) DEFAULT NULL,
+  phone VARCHAR(20) NOT NULL,
+  last_update TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (address_id),
+  KEY idx_fk_city_id (city_id),
+  CONSTRAINT fk_address_city FOREIGN KEY (city_id) REFERENCES city (city_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE category (
+  category_id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  name VARCHAR(25) NOT NULL,
+  last_update TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (category_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE language (
+  language_id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  name CHAR(20) NOT NULL,
+  last_update TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (language_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE film (
+  film_id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  title VARCHAR(255) NOT NULL,
+  description TEXT DEFAULT NULL,
+  release_year INT DEFAULT NULL,
+  language_id INT UNSIGNED NOT NULL,
+  original_language_id INT UNSIGNED DEFAULT NULL,
+  rental_duration TINYINT UNSIGNED NOT NULL DEFAULT 3,
+  rental_rate DECIMAL(4,2) NOT NULL DEFAULT 4.99,
+  length SMALLINT UNSIGNED DEFAULT NULL,
+  replacement_cost DECIMAL(5,2) NOT NULL DEFAULT 19.99,
+  rating ENUM('G','PG','PG-13','R','NC-17') DEFAULT 'G',
+  last_update TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (film_id),
+  KEY idx_title (title),
+  KEY idx_fk_language_id (language_id),
+  KEY idx_fk_original_language_id (original_language_id),
+  CONSTRAINT fk_film_language FOREIGN KEY (language_id) REFERENCES language (language_id),
+  CONSTRAINT fk_film_language_original FOREIGN KEY (original_language_id) REFERENCES language (language_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE film_actor (
+  actor_id INT UNSIGNED NOT NULL,
+  film_id INT UNSIGNED NOT NULL,
+  last_update TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (actor_id, film_id),
+  KEY idx_fk_film_id (film_id),
+  CONSTRAINT fk_film_actor_actor FOREIGN KEY (actor_id) REFERENCES actor (actor_id),
+  CONSTRAINT fk_film_actor_film FOREIGN KEY (film_id) REFERENCES film (film_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE film_category (
+  film_id INT UNSIGNED NOT NULL,
+  category_id INT UNSIGNED NOT NULL,
+  last_update TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (film_id, category_id),
+  CONSTRAINT fk_film_category_film FOREIGN KEY (film_id) REFERENCES film (film_id),
+  CONSTRAINT fk_film_category_category FOREIGN KEY (category_id) REFERENCES category (category_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE film_text (
+  film_id INT NOT NULL,
+  title VARCHAR(255) NOT NULL,
+  description TEXT,
+  PRIMARY KEY (film_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE store (
+  store_id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  manager_staff_id INT UNSIGNED NOT NULL,
+  address_id INT UNSIGNED NOT NULL,
+  last_update TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (store_id),
+  UNIQUE KEY idx_unique_manager (manager_staff_id),
+  KEY idx_fk_address_id (address_id),
+  CONSTRAINT fk_store_address FOREIGN KEY (address_id) REFERENCES address (address_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE staff (
+  staff_id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  first_name VARCHAR(45) NOT NULL,
+  last_name VARCHAR(45) NOT NULL,
+  address_id INT UNSIGNED NOT NULL,
+  email VARCHAR(50) DEFAULT NULL,
+  store_id INT UNSIGNED NOT NULL,
+  active BOOLEAN NOT NULL DEFAULT TRUE,
+  username VARCHAR(16) NOT NULL,
+  password VARCHAR(40) DEFAULT NULL,
+  last_update TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (staff_id),
+  KEY idx_fk_store_id (store_id),
+  KEY idx_fk_address_id (address_id),
+  CONSTRAINT fk_staff_store FOREIGN KEY (store_id) REFERENCES store (store_id),
+  CONSTRAINT fk_staff_address FOREIGN KEY (address_id) REFERENCES address (address_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE customer (
+  customer_id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  store_id INT UNSIGNED NOT NULL,
+  first_name VARCHAR(45) NOT NULL,
+  last_name VARCHAR(45) NOT NULL,
+  email VARCHAR(50) DEFAULT NULL,
+  address_id INT UNSIGNED NOT NULL,
+  active BOOLEAN NOT NULL DEFAULT TRUE,
+  create_date DATETIME NOT NULL,
+  last_update TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (customer_id),
+  KEY idx_fk_store_id (store_id),
+  KEY idx_fk_address_id (address_id),
+  KEY idx_last_name (last_name),
+  CONSTRAINT fk_customer_address FOREIGN KEY (address_id) REFERENCES address (address_id),
+  CONSTRAINT fk_customer_store FOREIGN KEY (store_id) REFERENCES store (store_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE inventory (
+  inventory_id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  film_id INT UNSIGNED NOT NULL,
+  store_id INT UNSIGNED NOT NULL,
+  last_update TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (inventory_id),
+  KEY idx_fk_film_id (film_id),
+  KEY idx_store_id_film_id (store_id, film_id),
+  CONSTRAINT fk_inventory_store FOREIGN KEY (store_id) REFERENCES store (store_id),
+  CONSTRAINT fk_inventory_film FOREIGN KEY (film_id) REFERENCES film (film_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE rental (
+  rental_id INT NOT NULL AUTO_INCREMENT,
+  rental_date DATETIME NOT NULL,
+  inventory_id INT UNSIGNED NOT NULL,
+  customer_id INT UNSIGNED NOT NULL,
+  return_date DATETIME DEFAULT NULL,
+  staff_id INT UNSIGNED NOT NULL,
+  last_update TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (rental_id),
+  UNIQUE KEY (rental_date, inventory_id, customer_id),
+  KEY idx_fk_inventory_id (inventory_id),
+  KEY idx_fk_customer_id (customer_id),
+  KEY idx_fk_staff_id (staff_id),
+  CONSTRAINT fk_rental_staff FOREIGN KEY (staff_id) REFERENCES staff (staff_id),
+  CONSTRAINT fk_rental_inventory FOREIGN KEY (inventory_id) REFERENCES inventory (inventory_id),
+  CONSTRAINT fk_rental_customer FOREIGN KEY (customer_id) REFERENCES customer (customer_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+CREATE TABLE payment (
+  payment_id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+  customer_id INT UNSIGNED NOT NULL,
+  staff_id INT UNSIGNED NOT NULL,
+  rental_id INT DEFAULT NULL,
+  amount DECIMAL(5,2) NOT NULL,
+  payment_date DATETIME NOT NULL,
+  last_update TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (payment_id),
+  KEY idx_fk_staff_id (staff_id),
+  KEY idx_fk_customer_id (customer_id),
+  CONSTRAINT fk_payment_rental FOREIGN KEY (rental_id) REFERENCES rental (rental_id),
+  CONSTRAINT fk_payment_customer FOREIGN KEY (customer_id) REFERENCES customer (customer_id),
+  CONSTRAINT fk_payment_staff FOREIGN KEY (staff_id) REFERENCES staff (staff_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
## Summary
- Add MySQL dialect support with full schema parsing and query validation
- Support MySQL-specific types: `TINYINT`, `MEDIUMINT`, `UNSIGNED` variants, `DATETIME`, inline `ENUM`
- Handle `AUTO_INCREMENT` as implicit NOT NULL
- Real-world testing with Sakila (16 tables, 40 queries) and Chinook MySQL (11 tables, 40 queries)

## Changes
- `dialect/mod.rs`: Add `SqlDialect::MySQL` with `MySqlDialect` parser
- `types/mod.rs`: Add `TinyInt`/`MediumInt` variants, map `Unsigned*`, `Datetime`, `Enum` types
- `builder.rs`: Handle `ColumnOption::DialectSpecific` for AUTO_INCREMENT
- `analyzer/mod.rs`: 10 MySQL-specific unit tests
- Test fixtures: Sakila (BSD) + Chinook (MIT) schemas with 80 valid queries + 24 error detection tests

## Test plan
- [x] 71 unit tests pass (61 existing + 10 new MySQL)
- [x] Sakila MySQL: 40/40 queries pass, 16 errors detected
- [x] Chinook MySQL: 40/40 queries pass, 17 errors detected
- [x] `cargo clippy` clean, `cargo fmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)