### PR TITLE
Release v0.1.0-alpha.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0-alpha.5] - 2026-02-08
+
+### Added
+- **MySQL dialect support**: Full schema parsing and query validation for MySQL
+- MySQL-specific types: `TINYINT`, `MEDIUMINT`, `UNSIGNED` integer variants, `DATETIME`, inline `ENUM`
+- `AUTO_INCREMENT` handling with implicit NOT NULL inference
+- 10 MySQL unit tests covering schema parsing, SELECT, JOIN, INSERT, UPDATE, DELETE, subquery, CTE, and error detection
+- Real-world MySQL test fixtures:
+  - **Sakila** (BSD): 16 tables, 40 valid queries, 12 error detection tests
+  - **Chinook MySQL** (MIT): 11 tables, 40 valid queries, 12 error detection tests
+
 ## [0.1.0-alpha.4] - 2026-02-08
 
 ### Added
@@ -91,7 +102,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - No support for VIEWs, functions, or stored procedures
 - Derived table (subquery in FROM) column resolution is incomplete
 
-[Unreleased]: https://github.com/yukikotani231/sqlsurge/compare/v0.1.0-alpha.4...HEAD
+[Unreleased]: https://github.com/yukikotani231/sqlsurge/compare/v0.1.0-alpha.5...HEAD
+[0.1.0-alpha.5]: https://github.com/yukikotani231/sqlsurge/compare/v0.1.0-alpha.4...v0.1.0-alpha.5
 [0.1.0-alpha.4]: https://github.com/yukikotani231/sqlsurge/compare/v0.1.0-alpha.3...v0.1.0-alpha.4
 [0.1.0-alpha.3]: https://github.com/yukikotani231/sqlsurge/compare/v0.1.0-alpha.2...v0.1.0-alpha.3
 [0.1.0-alpha.2]: https://github.com/yukikotani231/sqlsurge/compare/v0.1.0-alpha.1...v0.1.0-alpha.2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,7 +122,7 @@ cargo run -- check --format sarif --schema schema.sql query.sql
 - Integration tests use SQL fixtures in `tests/fixtures/`
 - Real-world schema tests in `tests/fixtures/real-world/` (Chinook, Pagila, Northwind) with valid and invalid query files
 - Test both positive cases (valid SQL) and negative cases (should produce diagnostics)
-- Comprehensive test coverage: 61 unit tests + 72 PostgreSQL pattern tests covering DDL parsing, SELECT, INSERT, UPDATE, DELETE, CTEs, subqueries, VIEWs, ALTER TABLE, derived tables, window functions, and advanced expressions
+- Comprehensive test coverage: 71 unit tests + 72 PostgreSQL pattern tests + 80 MySQL real-world queries covering DDL parsing, SELECT, INSERT, UPDATE, DELETE, CTEs, subqueries, VIEWs, ALTER TABLE, derived tables, window functions, and advanced expressions
 - Test-driven development (TDD) approach: write failing tests first, then implement features
 
 ## Style Guidelines
@@ -135,7 +135,7 @@ cargo run -- check --format sarif --schema schema.sql query.sql
 
 ## Current Limitations
 
-- Only PostgreSQL dialect is fully supported (MySQL/SQLite planned)
+- SQLite dialect is not yet supported
 - Type checking is basic (existence only, not full type inference)
 - Functions and stored procedures are skipped (not analyzed)
 - Schema-qualified names (e.g., `public.users`) are not fully resolved

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/sqlsurge-core", "crates/sqlsurge-cli"]
 
 [workspace.package]
-version = "0.1.0-alpha.4"
+version = "0.1.0-alpha.5"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/yukikotani231/sqlsurge"
@@ -32,7 +32,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 glob = "0.3"
 
 # Internal crates
-sqlsurge-core = { path = "crates/sqlsurge-core", version = "0.1.0-alpha.4" }
+sqlsurge-core = { path = "crates/sqlsurge-core", version = "0.1.0-alpha.5" }
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/README.md
+++ b/README.md
@@ -202,16 +202,17 @@ sqlsurge check -s schema.sql -f sarif queries/*.sql > results.sarif
 ## Supported SQL Dialects
 
 - **PostgreSQL** (default) — fully supported
-- MySQL — planned
+- **MySQL** — supported (`--dialect mysql`)
 - SQLite — planned
 
-Use the `--dialect` flag to specify the dialect (currently only `postgresql` is supported).
+Use the `--dialect` flag to specify the dialect.
 
 ## Roadmap
 
 - [x] Configuration file (`sqlsurge.toml`)
+- [x] MySQL dialect support
 - [ ] LSP server for editor integration
-- [ ] MySQL and SQLite dialect support
+- [ ] SQLite dialect support
 - [ ] Type inference for expressions
 - [ ] Custom rule plugins
 


### PR DESCRIPTION
## Summary
- Bump version to 0.1.0-alpha.5
- CHANGELOG entry for MySQL dialect support
- Update README and CLAUDE.md to reflect MySQL support

## Test plan
- [x] `cargo test` passes
- [x] Version updated in Cargo.toml

🤖 Generated with [Claude Code](https://claude.com/claude-code)