### PR TITLE
fix: add actions:write permission to auto-tag workflow

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   tag:

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -12,10 +12,12 @@ set -euo pipefail
 # 5. Creates a release branch, commits, and pushes
 # 6. Creates a PR via gh CLI
 #
-# After the PR is merged, the auto-tag workflow (.github/workflows/auto-tag.yml)
-# automatically creates and pushes the git tag, which triggers the release workflow.
+# After the PR is merged, everything is fully automated:
+#   auto-tag.yml: creates git tag + triggers release workflow via workflow_dispatch
+#   release.yml: builds binaries + creates GitHub Release + publishes npm package
 #
-# Manual tagging (if needed): ./scripts/release.sh --tag <version>
+# Manual tagging should not be needed. If the automation fails,
+# you can use: ./scripts/release.sh --tag <version>
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"


### PR DESCRIPTION
## Summary
- `auto-tag.yml` の `gh workflow run release.yml` が `HTTP 403: Resource not accessible by integration` で失敗していた問題を修正
- `permissions` に `actions: write` を追加し、PR マージ後の release.yml 自動トリガーを有効化
- `release.sh` のコメントを更新（マージ後のフローが完全自動である旨を明記）

## Test plan
- [ ] 次回リリース（alpha.8）で auto-tag → release.yml の自動連鎖を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)