### PR TITLE
feat: add INSERT VALUES and UPDATE SET type checking (E0003)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,10 +160,10 @@ cargo run -- check --format sarif --schema schema.sql query.sql
 - Binary operator type validation (=, <, >, <=, >=, !=, +, -, *, /, %)
 - Nested expression type inference
 - Numeric type compatibility (TINYINT → BIGINT implicit casts)
+- INSERT VALUES type checking (`INSERT INTO users (id) VALUES ('text')` → E0003)
+- UPDATE SET type checking (`UPDATE users SET id = 'text'` → E0003)
 
 **Not Yet Implemented (TODO):**
-- INSERT VALUES type checking (`INSERT INTO users (id) VALUES ('text')`)
-- UPDATE SET type checking (`UPDATE users SET id = 'text'`)
 - CAST expression type inference (`CAST(x AS INTEGER)`)
 - Function return type inference (COUNT → INTEGER, SUM → NUMERIC, etc.)
 - CASE expression type consistency (THEN/ELSE must have compatible types)
@@ -171,8 +171,7 @@ cargo run -- check --format sarif --schema schema.sql query.sql
 - VIEW column type inference from SELECT projection
 
 **Implementation Notes:**
-- Current type inference covers ~70-80% of real-world type errors
-- Missing features have lower ROI (INSERT/UPDATE would add ~15%, rest combined ~5%)
+- Current type inference covers ~85% of real-world type errors
 - See `crates/sqlsift-core/src/analyzer/type_resolver.rs` for implementation
 
 ### Other Limitations

--- a/crates/sqlsift-core/src/types/mod.rs
+++ b/crates/sqlsift-core/src/types/mod.rs
@@ -204,6 +204,11 @@ impl SqlType {
             // String to UUID coercion (PostgreSQL implicit cast)
             (Char { .. } | Varchar { .. } | Text, Uuid) => TypeCompatibility::ImplicitCast,
 
+            // String to ENUM coercion (ENUM values are string literals)
+            (Char { .. } | Varchar { .. } | Text, Custom(name)) if name == "ENUM" => {
+                TypeCompatibility::ImplicitCast
+            }
+
             // Any type can be explicitly cast
             _ => TypeCompatibility::ExplicitCast,
         }


### PR DESCRIPTION
## Summary
- Detect type mismatches in `INSERT INTO ... VALUES (...)` and `UPDATE ... SET col = val` statements
- Reuses existing `TypeResolver` infrastructure for type inference
- Adds `Text → ENUM` implicit cast compatibility to prevent false positives

## Test plan
- [x] `test_insert_type_mismatch`: `INSERT INTO users (id) VALUES ('text')` → E0003
- [x] `test_insert_type_compatible`: `INSERT INTO users (id) VALUES (42)` → OK
- [x] `test_insert_null_compatible`: `INSERT INTO users (id) VALUES (NULL)` → OK
- [x] `test_update_type_mismatch`: `UPDATE users SET id = 'text'` → E0003
- [x] `test_update_type_compatible`: `UPDATE users SET name = 'new'` → OK
- [x] `test_update_multiple_type_errors`: 複数 SET 句での複数エラー
- [x] All 88 integration tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)