### PR TITLE
feat: add SQLite dialect support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,7 +150,6 @@ cargo run -- check --format sarif --schema schema.sql query.sql
 ## Current Limitations
 
 ### SQL Dialect Support
-- SQLite dialect is not yet supported (PostgreSQL and MySQL are supported)
 - Schema-qualified names (e.g., `public.users`) are not fully resolved
 
 ### Type Inference (Partial Implementation)

--- a/crates/sqlsift-core/src/dialect/mod.rs
+++ b/crates/sqlsift-core/src/dialect/mod.rs
@@ -1,6 +1,6 @@
 //! SQL dialect support
 
-use sqlparser::dialect::{Dialect, MySqlDialect, PostgreSqlDialect};
+use sqlparser::dialect::{Dialect, MySqlDialect, PostgreSqlDialect, SQLiteDialect};
 use std::str::FromStr;
 
 /// Supported SQL dialects
@@ -9,6 +9,7 @@ pub enum SqlDialect {
     #[default]
     PostgreSQL,
     MySQL,
+    SQLite,
 }
 
 impl SqlDialect {
@@ -17,6 +18,7 @@ impl SqlDialect {
         match self {
             SqlDialect::PostgreSQL => Box::new(PostgreSqlDialect {}),
             SqlDialect::MySQL => Box::new(MySqlDialect {}),
+            SqlDialect::SQLite => Box::new(SQLiteDialect {}),
         }
     }
 
@@ -24,7 +26,7 @@ impl SqlDialect {
     pub fn default_schema(&self) -> &'static str {
         match self {
             SqlDialect::PostgreSQL => "public",
-            SqlDialect::MySQL => "",
+            SqlDialect::MySQL | SqlDialect::SQLite => "",
         }
     }
 }
@@ -36,12 +38,9 @@ impl FromStr for SqlDialect {
         match s.to_lowercase().as_str() {
             "postgresql" | "postgres" | "pg" => Ok(SqlDialect::PostgreSQL),
             "mysql" | "mysql8" => Ok(SqlDialect::MySQL),
-            "sqlite" => Err(
-                "SQLite dialect is not yet supported. Supported dialects: postgresql, mysql."
-                    .to_string(),
-            ),
+            "sqlite" | "sqlite3" => Ok(SqlDialect::SQLite),
             _ => Err(format!(
-                "Unknown dialect: '{}'. Supported dialects: postgresql, mysql.",
+                "Unknown dialect: '{}'. Supported dialects: postgresql, mysql, sqlite.",
                 s
             )),
         }
@@ -53,6 +52,7 @@ impl std::fmt::Display for SqlDialect {
         match self {
             SqlDialect::PostgreSQL => write!(f, "postgresql"),
             SqlDialect::MySQL => write!(f, "mysql"),
+            SqlDialect::SQLite => write!(f, "sqlite"),
         }
     }
 }

--- a/crates/sqlsift-core/src/schema/builder.rs
+++ b/crates/sqlsift-core/src/schema/builder.rs
@@ -498,12 +498,12 @@ impl SchemaBuilder {
                 }
             }
             ColumnOption::DialectSpecific(tokens) => {
-                // MySQL AUTO_INCREMENT
+                // MySQL AUTO_INCREMENT / SQLite AUTOINCREMENT
                 if tokens
                     .iter()
-                    .any(|t| matches!(t, Token::Word(w) if w.value == "AUTO_INCREMENT"))
+                    .any(|t| matches!(t, Token::Word(w) if w.value == "AUTO_INCREMENT" || w.value == "AUTOINCREMENT"))
                 {
-                    col.nullable = false; // AUTO_INCREMENT implies NOT NULL
+                    col.nullable = false; // AUTO_INCREMENT/AUTOINCREMENT implies NOT NULL
                 }
             }
             _ => {}


### PR DESCRIPTION
## Summary
- Add `SQLite` variant to `SqlDialect` enum (parser, default_schema, FromStr, Display)
- Detect SQLite `AUTOINCREMENT` in `builder.rs` (same `DialectSpecific` pattern as MySQL's `AUTO_INCREMENT`)
- Add 6 integration tests covering schema parsing, SELECT, AUTOINCREMENT, INSERT, UPDATE, DELETE

**Depends on:** #24 (INSERT/UPDATE type checking)

## Test plan
- [x] `test_sqlite_schema_parsing`: SQLite DDL パース
- [x] `test_sqlite_valid_select`: 基本クエリ
- [x] `test_sqlite_autoincrement`: AUTOINCREMENT カラム
- [x] `test_sqlite_insert`: INSERT + 型チェック
- [x] `test_sqlite_update`: UPDATE + 型チェック
- [x] `test_sqlite_delete`: DELETE + カラム検証
- [x] All 94 integration tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)