### PR TITLE
chore: add pre-commit hook for fmt and clippy

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Running pre-commit checks..."
+
+# Check formatting
+if ! cargo fmt --all -- --check 2>/dev/null; then
+    echo ""
+    echo "ERROR: Formatting check failed."
+    echo "Run 'cargo fmt' to fix, then re-commit."
+    exit 1
+fi
+
+# Run clippy
+if ! cargo clippy --all-targets -- -D warnings 2>/dev/null; then
+    echo ""
+    echo "ERROR: Clippy check failed. Fix warnings above, then re-commit."
+    exit 1
+fi
+
+echo "Pre-commit checks passed."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,13 +65,20 @@ Schema SQL → sqlparser → AST → SchemaBuilder → Catalog
 Query SQL  → sqlparser → AST → Analyzer → NameResolver → TypeResolver → Diagnostics
 ```
 
+## Setup
+
+```bash
+# Enable pre-commit hooks (fmt + clippy checks)
+git config core.hooksPath .githooks
+```
+
 ## Build & Test Commands
 
 ```bash
 # Build
 cargo build
 
-# Run tests (137 tests: 28 unit + 94 integration + 3 doc + 12 LSP)
+# Run tests (141 tests: 28 unit + 98 integration + 3 doc + 12 LSP)
 cargo test
 
 # Run with example


### PR DESCRIPTION
## Summary
- `.githooks/pre-commit` を追加: コミット前に `cargo fmt --check` と `cargo clippy` を自動実行
- CI の fmt 差分によるリトライを防止

## Setup
```bash
git config core.hooksPath .githooks
```

## Test plan
- [x] コミット時にフックが実行されることを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)