### PR TITLE
chore: release v0.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/sqlsift-core", "crates/sqlsift-cli", "crates/sqlsift-lsp"]
 
 [workspace.package]
-version = "0.1.0-alpha.8"
+version = "0.1.0"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/yukikotani231/sqlsift"
@@ -36,7 +36,7 @@ tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
 
 # Internal crates
-sqlsift-core = { path = "crates/sqlsift-core", version = "0.1.0-alpha.8" }
+sqlsift-core = { path = "crates/sqlsift-core", version = "0.1.0" }
 
 # The profile that 'dist' will build with
 [profile.dist]


### PR DESCRIPTION
## Summary
- alpha を卒業して `v0.1.0` 安定版リリース
- 以降は release-plz による標準 semver バージョンバンプが機能する

## v0.1.0 の主な機能
- SQL静的解析（SELECT, INSERT, UPDATE, DELETE）
- 3 dialects: PostgreSQL, MySQL, SQLite
- 型推論: WHERE, JOIN, INSERT VALUES, UPDATE SET, CAST
- LSP サーバー + VS Code 拡張
- JSON / SARIF 出力
- 設定ファイル (sqlsift.toml)

## Test plan
- [x] `cargo check` 通過
- [ ] CI passes
- [ ] After merge, release-plz creates `v0.1.0` tag → cargo-dist builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)