### PR TITLE
fix: auto-trigger cargo-dist after release-plz creates tag

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -18,11 +19,20 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Run release-plz
+        id: release-plz
         uses: release-plz/action@main
         with:
           command: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Trigger cargo-dist release
+        if: steps.release-plz.outputs.releases_created == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for tag in $(echo '${{ steps.release-plz.outputs.releases }}' | jq -r '.[].tag'); do
+            gh workflow run release.yml --ref "$tag"
+          done
 
   release-plz-pr:
     name: Release-plz PR


### PR DESCRIPTION
## Summary
- GITHUB_TOKENで作成されたタグはpushイベントをトリガーしない（GitHub制限）
- release-plzの`releases_created`/`releases` outputを使い、タグ作成後に`gh workflow run release.yml`で自動トリガー
- `actions: write`権限を追加

## Test plan
- [ ] 次回リリース時にrelease-plzがタグ作成→release.ymlが自動実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)