### PR TITLE
chore: switch npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,6 +284,8 @@ jobs:
       - plan
       - host
     runs-on: "ubuntu-22.04"
+    permissions:
+      id-token: write
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       PLAN: ${{ needs.plan.outputs.val }}
@@ -302,10 +304,8 @@ jobs:
       - run: |
           for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith("-npm-package.tar.gz")] | any)'); do
             pkg=$(echo "$release" | jq '.artifacts[] | select(endswith("-npm-package.tar.gz"))' --raw-output)
-            npm publish --access public "./npm/${pkg}"
+            npm publish --access public --provenance "./npm/${pkg}"
           done
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   announce:
     needs:


### PR DESCRIPTION
## Summary
- NPM_TOKEN秘密鍵を廃止し、OIDC trusted publishingに移行
- `id-token: write`権限を追加、`--provenance`フラグでpublish
- npmjs.comで両パッケージにtrusted publisher設定済み

## Test plan
- [ ] 次回リリース時にnpm publishがOIDC経由で成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)