### PR TITLE
fix: only trigger cargo-dist for sqlsift-cli tags

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -30,7 +30,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          for tag in $(echo '${{ steps.release-plz.outputs.releases }}' | jq -r '.[].tag'); do
+          for tag in $(echo '${{ steps.release-plz.outputs.releases }}' | jq -r '.[] | select(.tag | test("^v")) | .tag'); do
             gh workflow run release.yml --ref "$tag"
           done
 


### PR DESCRIPTION
## Summary
- release-plzが`sqlsift-core`/`sqlsift-lsp`のリリースも報告するが、タグは`sqlsift-cli`のみ作成される
- 存在しないref（`sqlsift-core-v0.1.0`）で`gh workflow run`して422エラーになっていた
- `^v`パターンでフィルタし、`v{version}`形式のタグのみトリガー対象に

## Test plan
- [ ] 次回リリース時にrelease-plzジョブがエラーなく完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)