### PR TITLE
chore: use PAT for release-plz to auto-trigger cargo-dist

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -10,29 +10,20 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      actions: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Run release-plz
-        id: release-plz
         uses: release-plz/action@main
         with:
           command: release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Trigger cargo-dist release
-        if: steps.release-plz.outputs.releases_created == 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          for tag in $(echo '${{ steps.release-plz.outputs.releases }}' | jq -r '.[] | select(.tag | test("^v")) | .tag'); do
-            gh workflow run release.yml --ref "$tag"
-          done
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}
 
   release-plz-pr:
     name: Release-plz PR
@@ -48,6 +39,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_PLZ_TOKEN }}
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Run release-plz
@@ -55,4 +47,4 @@ jobs:
         with:
           command: release-pr
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN }}


### PR DESCRIPTION
## Summary
- `GITHUB_TOKEN` → `RELEASE_PLZ_TOKEN`（Fine-grained PAT）に変更
- PAT経由のタグ作成は`on: push: tags`を自然にトリガーする
- `workflow_dispatch`回避ステップとタグフィルタを削除
- `actions: write`権限も不要に

これが[release-plz公式ドキュメント](https://release-plz.dev/docs/github/token)の推奨構成です。

## Test plan
- [ ] 次回リリース時にタグ作成→release.ymlが自動トリガーされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)