### PR TITLE
fix: enable git_only mode for release-plz

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,6 +1,8 @@
 [workspace]
 # Don't publish to crates.io (cargo-dist handles distribution via npm)
 publish = false
+# Use git tags as version baseline (not crates.io registry)
+git_only = true
 # Don't create GitHub releases (cargo-dist handles this via release.yml)
 git_release_enable = false
 # Don't create git tags by default


### PR DESCRIPTION
## Summary
- `release-plz.toml`に`git_only = true`を追加
- release-plzがcrates.ioではなくgitタグをバージョンベースラインとして使用するように変更

## 問題
`publish = false`（crates.ioに公開しない）設定のため、release-plzはレジストリに公開済みバージョンを見つけられず、既に存在するv0.1.0を繰り返し提案していた（PR #40）。

## 修正
`git_only = true`により:
- 既存の`v0.1.0`タグをベースラインとして認識
- v0.1.0以降のconventional commitsに基づいて正しくバージョンバンプ
- pre-1.0ではデフォルトで`feat:`→パッチバンプ（0.1.0→0.1.1）

🤖 Generated with [Claude Code](https://claude.com/claude-code)