### PR TITLE
fix: fix npm OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -300,7 +300,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
+      - name: Upgrade npm for OIDC trusted publishing support
+        run: npm install -g npm@latest
       - run: |
           for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith("-npm-package.tar.gz")] | any)'); do
             pkg=$(echo "$release" | jq '.artifacts[] | select(endswith("-npm-package.tar.gz"))' --raw-output)


### PR DESCRIPTION
## Summary
- `actions/setup-node`から`registry-url`を削除（空トークン`.npmrc`問題を回避）
- `npm install -g npm@latest`でnpm 11.5.1+にアップグレード（OIDCハンドシェイク対応）

## 問題
v0.1.1リリースでnpm publishが`E404 / Access token expired or revoked`で失敗していた。

**原因1**: `registry-url`指定により`.npmrc`に`_authToken=${NODE_AUTH_TOKEN}`が書かれ、未設定の場合に空トークンで認証→OIDCフォールバックに進まない

**原因2**: Node.js 20.x同梱のnpm 10.xはOIDC Trusted Publishingのハンドシェイクプロトコルを未サポート（npm >= 11.5.1が必要）

## Test plan
- [ ] マージ後、v0.1.1のRelease workflowのpublish-npmジョブを再実行して成功を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)