### PR TITLE
fix: clear NODE_AUTH_TOKEN placeholder for npm OIDC publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -300,12 +300,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
+          registry-url: 'https://registry.npmjs.org'
       - name: Upgrade npm for OIDC trusted publishing support
         run: npm install -g npm@latest
       - run: |
           for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith("-npm-package.tar.gz")] | any)'); do
             pkg=$(echo "$release" | jq '.artifacts[] | select(endswith("-npm-package.tar.gz"))' --raw-output)
-            npm publish --access public --provenance "./npm/${pkg}"
+            NODE_AUTH_TOKEN="" npm publish --access public --provenance "./npm/${pkg}"
           done
 
   announce:

--- a/.github/workflows/test-npm-oidc.yml
+++ b/.github/workflows/test-npm-oidc.yml
@@ -20,13 +20,6 @@ jobs:
         run: |
           npm install -g npm@latest
           echo "npm version: $(npm --version)"
-      - name: Remove empty auth token from .npmrc
-        run: |
-          echo "=== .npmrc before ==="
-          cat "$NPM_CONFIG_USERCONFIG" || cat ~/.npmrc || echo "no .npmrc found"
-          npm config delete //registry.npmjs.org/:_authToken 2>/dev/null || true
-          echo "=== .npmrc after ==="
-          cat "$NPM_CONFIG_USERCONFIG" || cat ~/.npmrc || echo "no .npmrc found"
       - name: Download v0.1.1 npm package from GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -35,4 +28,4 @@ jobs:
             "https://github.com/yukikotani231/sqlsift/releases/download/v0.1.1/sqlsift-cli-npm-package.tar.gz"
           ls -la sqlsift-cli-npm-package.tar.gz
       - name: Publish with OIDC
-        run: npm publish --access public --provenance sqlsift-cli-npm-package.tar.gz
+        run: NODE_AUTH_TOKEN="" npm publish --access public --provenance sqlsift-cli-npm-package.tar.gz


### PR DESCRIPTION
## Summary

- `actions/setup-node` の `registry-url` 使用時にセットされる `NODE_AUTH_TOKEN` プレースホルダーが npm の OIDC フォールバックを阻害していた
- `NODE_AUTH_TOKEN=""` プレフィックスで `npm publish` 前にプレースホルダーを無効化
- `release.yml` の `setup-node` に `registry-url` を追加（レジストリ設定の正規化）

## Changes

### `.github/workflows/test-npm-oidc.yml`
- `.npmrc` 手動クリーンアップステップを削除（`NODE_AUTH_TOKEN=""` で代替）
- `npm publish` に `NODE_AUTH_TOKEN=""` プレフィックスを追加

### `.github/workflows/release.yml`
- `setup-node` に `registry-url: 'https://registry.npmjs.org'` を追加
- `npm publish` に `NODE_AUTH_TOKEN=""` プレフィックスを追加

## Test plan

- [ ] このPRをmainにマージ
- [ ] `test-npm-oidc` ワークフローを `workflow_dispatch` で実行
- [ ] v0.1.1のnpmパッケージが正常にpublishされることを確認

## References

- [actions/setup-node#1440](https://github.com/actions/setup-node/issues/1440)
- [GitHub Community #176761](https://github.com/orgs/community/discussions/176761)

🤖 Generated with [Claude Code](https://claude.com/claude-code)