### PR TITLE
fix: avoid registry-url to prevent authToken blocking OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -300,13 +300,14 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
       - name: Upgrade npm for OIDC trusted publishing support
         run: npm install -g npm@latest
+      - name: Configure npm registry
+        run: npm config set registry https://registry.npmjs.org/
       - run: |
           for release in $(echo "$PLAN" | jq --compact-output '.releases[] | select([.artifacts[] | endswith("-npm-package.tar.gz")] | any)'); do
             pkg=$(echo "$release" | jq '.artifacts[] | select(endswith("-npm-package.tar.gz"))' --raw-output)
-            NODE_AUTH_TOKEN="" npm publish --access public --provenance "./npm/${pkg}"
+            npm publish --access public --provenance "./npm/${pkg}"
           done
 
   announce:

--- a/.github/workflows/test-npm-oidc.yml
+++ b/.github/workflows/test-npm-oidc.yml
@@ -15,11 +15,12 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '20.x'
-          registry-url: 'https://registry.npmjs.org'
       - name: Upgrade npm for OIDC support
         run: |
           npm install -g npm@latest
           echo "npm version: $(npm --version)"
+      - name: Configure npm registry
+        run: npm config set registry https://registry.npmjs.org/
       - name: Download v0.1.1 npm package from GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -28,4 +29,4 @@ jobs:
             "https://github.com/yukikotani231/sqlsift/releases/download/v0.1.1/sqlsift-cli-npm-package.tar.gz"
           ls -la sqlsift-cli-npm-package.tar.gz
       - name: Publish with OIDC
-        run: NODE_AUTH_TOKEN="" npm publish --access public --provenance sqlsift-cli-npm-package.tar.gz
+        run: npm publish --access public --provenance sqlsift-cli-npm-package.tar.gz


### PR DESCRIPTION
## Summary

- 前回の修正 (#46) で `NODE_AUTH_TOKEN=""` プレフィックスを追加したが、`.npmrc` に `_authToken=${NODE_AUTH_TOKEN}` が残るため空文字列のトークンとして解釈され `ENEEDAUTH` エラーが発生
- `registry-url` の使用を止め、`npm config set registry` でレジストリを設定することで `.npmrc` に authToken 行が書かれないようにする
- これにより npm が OIDC フォールバックを正しく実行できる

## Changes

- `setup-node` から `registry-url` を削除
- `npm config set registry https://registry.npmjs.org/` ステップを追加
- `NODE_AUTH_TOKEN=""` プレフィックスを削除（不要になったため）

## Test plan

- [ ] mainにマージ後、`test-npm-oidc` ワークフローを `workflow_dispatch` で実行
- [ ] v0.1.1 のnpmパッケージが正常にpublishされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)