### PR TITLE
fix: set workspace git_tag_name for release-plz change detection

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -9,9 +9,10 @@ git_release_enable = false
 git_tag_enable = false
 # Skip semver checks during alpha development
 semver_check = false
+# Use v{version} tag pattern for all packages (multi-package default is "{package}-v{version}")
+git_tag_name = "v{{ version }}"
 
 # Only create a tag for sqlsift-cli (triggers cargo-dist release.yml)
 [[package]]
 name = "sqlsift-cli"
 git_tag_enable = true
-git_tag_name = "v{{ version }}"


### PR DESCRIPTION
## Summary

- release-plz がマルチパッケージワークスペースで `git_tag_name` のデフォルト `"{{ package }}-v{{ version }}"` を使用していたため、`sqlsift-core` と `sqlsift-lsp` のベースラインタグが見つからず Release PR が作成されなかった
- ワークスペースレベルに `git_tag_name = "v{{ version }}"` を追加し、全パッケージが `v0.1.1` タグをベースラインとして使うように修正

## Test plan

- [ ] マージ後、release-plz が v0.1.2 への Release PR を自動生成することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)