### PR TITLE
chore: release v0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "sqlsift-cli"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "clap",
  "glob",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "sqlsift-core"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "indexmap",
  "miette",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "sqlsift-lsp"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "glob",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/sqlsift-core", "crates/sqlsift-cli", "crates/sqlsift-lsp"]
 
 [workspace.package]
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/yukikotani231/sqlsift"
@@ -36,7 +36,7 @@ tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
 
 # Internal crates
-sqlsift-core = { path = "crates/sqlsift-core", version = "0.1.1" }
+sqlsift-core = { path = "crates/sqlsift-core", version = "0.1.2" }
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/crates/sqlsift-cli/CHANGELOG.md
+++ b/crates/sqlsift-cli/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/yukikotani231/sqlsift/compare/v0.1.1...v0.1.2) - 2026-02-19
+
+### Added
+
+- add inline comment directives for diagnostic suppression ([#52](https://github.com/yukikotani231/sqlsift/pull/52))
+
+### Other
+
+- add GitHub templates and CI integration examples ([#54](https://github.com/yukikotani231/sqlsift/pull/54))
+
 ## [0.1.1](https://github.com/yukikotani231/sqlsift/compare/v0.1.0...v0.1.1) - 2026-02-14
 
 ### Other

--- a/crates/sqlsift-core/CHANGELOG.md
+++ b/crates/sqlsift-core/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/yukikotani231/sqlsift/compare/v0.1.1...v0.1.2) - 2026-02-19
+
+### Added
+
+- support DROP TABLE to keep schema catalog in sync ([#55](https://github.com/yukikotani231/sqlsift/pull/55))
+- add inline comment directives for diagnostic suppression ([#52](https://github.com/yukikotani231/sqlsift/pull/52))
+
+### Fixed
+
+- isolate subquery scope to prevent false E0006 ambiguity ([#60](https://github.com/yukikotani231/sqlsift/pull/60))
+- support INSERT/UPDATE RETURNING columns in CTE inference ([#59](https://github.com/yukikotani231/sqlsift/pull/59))
+
+### Other
+
+- add GitHub templates and CI integration examples ([#54](https://github.com/yukikotani231/sqlsift/pull/54))
+
 ## [0.1.1](https://github.com/yukikotani231/sqlsift/compare/sqlsift-core-v0.1.0...sqlsift-core-v0.1.1) - 2026-02-14
 
 ### Added

--- a/crates/sqlsift-lsp/CHANGELOG.md
+++ b/crates/sqlsift-lsp/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.2](https://github.com/yukikotani231/sqlsift/compare/v0.1.1...v0.1.2) - 2026-02-19
+
+### Added
+
+- add LSP auto-completion for table/column/view names ([#53](https://github.com/yukikotani231/sqlsift/pull/53))
+- add inline comment directives for diagnostic suppression ([#52](https://github.com/yukikotani231/sqlsift/pull/52))
+- add textDocument/hover for table, view, and column info ([#49](https://github.com/yukikotani231/sqlsift/pull/49))
+
+### Other
+
+- add GitHub templates and CI integration examples ([#54](https://github.com/yukikotani231/sqlsift/pull/54))
+
 ## [0.1.1](https://github.com/yukikotani231/sqlsift/compare/sqlsift-lsp-v0.1.0...sqlsift-lsp-v0.1.1) - 2026-02-14
 
 ### Other


### PR DESCRIPTION



## 🤖 New release

* `sqlsift-core`: 0.1.1 -> 0.1.2
* `sqlsift-cli`: 0.1.1 -> 0.1.2
* `sqlsift-lsp`: 0.1.1 -> 0.1.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `sqlsift-core`

<blockquote>

## [0.1.2](https://github.com/yukikotani231/sqlsift/compare/v0.1.1...v0.1.2) - 2026-02-19

### Added

- support DROP TABLE to keep schema catalog in sync ([#55](https://github.com/yukikotani231/sqlsift/pull/55))
- add inline comment directives for diagnostic suppression ([#52](https://github.com/yukikotani231/sqlsift/pull/52))

### Fixed

- isolate subquery scope to prevent false E0006 ambiguity ([#60](https://github.com/yukikotani231/sqlsift/pull/60))
- support INSERT/UPDATE RETURNING columns in CTE inference ([#59](https://github.com/yukikotani231/sqlsift/pull/59))

### Other

- add GitHub templates and CI integration examples ([#54](https://github.com/yukikotani231/sqlsift/pull/54))
</blockquote>

## `sqlsift-cli`

<blockquote>

## [0.1.2](https://github.com/yukikotani231/sqlsift/compare/v0.1.1...v0.1.2) - 2026-02-19

### Added

- add inline comment directives for diagnostic suppression ([#52](https://github.com/yukikotani231/sqlsift/pull/52))

### Other

- add GitHub templates and CI integration examples ([#54](https://github.com/yukikotani231/sqlsift/pull/54))
</blockquote>

## `sqlsift-lsp`

<blockquote>

## [0.1.2](https://github.com/yukikotani231/sqlsift/compare/v0.1.1...v0.1.2) - 2026-02-19

### Added

- add LSP auto-completion for table/column/view names ([#53](https://github.com/yukikotani231/sqlsift/pull/53))
- add inline comment directives for diagnostic suppression ([#52](https://github.com/yukikotani231/sqlsift/pull/52))
- add textDocument/hover for table, view, and column info ([#49](https://github.com/yukikotani231/sqlsift/pull/49))

### Other

- add GitHub templates and CI integration examples ([#54](https://github.com/yukikotani231/sqlsift/pull/54))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).