### PR TITLE
feat: add LSP auto-completion for table/column/view names

### DIFF
--- a/crates/sqlsift-lsp/src/server.rs
+++ b/crates/sqlsift-lsp/src/server.rs
@@ -72,6 +72,10 @@ impl LanguageServer for Backend {
                     },
                 )),
                 hover_provider: Some(HoverProviderCapability::Simple(true)),
+                completion_provider: Some(CompletionOptions {
+                    trigger_characters: Some(vec![".".to_string(), " ".to_string()]),
+                    ..Default::default()
+                }),
                 ..Default::default()
             },
             ..Default::default()
@@ -202,6 +206,17 @@ impl LanguageServer for Backend {
                 range: None,
             })),
             None => Ok(None),
+        }
+    }
+
+    async fn completion(&self, _params: CompletionParams) -> Result<Option<CompletionResponse>> {
+        let state = self.state.read().await;
+        let items = state.completion_items();
+
+        if items.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(CompletionResponse::Array(items)))
         }
     }
 }


### PR DESCRIPTION
## Summary
- Implement `textDocument/completion` LSP handler for schema-aware auto-completion
- Table names shown as `CompletionItemKind::Class` with column list in documentation
- Column names shown as `CompletionItemKind::Field` with type info and parent table
- View names shown as `CompletionItemKind::Interface` with column list
- Trigger characters: `.` and ` ` (space)

## Test plan
- [x] 3 unit tests for completion_items (tables+columns, views, empty catalog)
- [x] All 184 tests pass
- [x] clippy clean (`-D warnings`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)