### PR TITLE
feat: implement E0004 null-violation diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Validate set operation compatibility (`UNION` / `INTERSECT` / `EXCEPT`) for column count and type mismatches
 - Add integration tests for CLI behavior (`--max-errors`, `-q`, `-v`)
+- Implement `E0004` detection for explicit `NULL` assignment to `NOT NULL` columns in `INSERT` / `UPDATE`
 
 ### Changed
 - Wire up CLI runtime behavior for `--max-errors` early stop

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ sqlsift check --schema schema/*.sql queries/**/*.sql
 | E0001 | table-not-found | Referenced table does not exist in schema | ✅ Implemented |
 | E0002 | column-not-found | Referenced column does not exist in table | ✅ Implemented |
 | E0003 | type-mismatch | Type incompatibility in expressions (comparisons, arithmetic) | ✅ Implemented |
-| E0004 | potential-null-violation | Possible NOT NULL constraint violation | 🚧 Reserved |
+| E0004 | potential-null-violation | Potential NOT NULL violation (explicit NULL assignment) | ✅ Implemented |
 | E0005 | column-count-mismatch | INSERT column count doesn't match values | ✅ Implemented |
 | E0006 | ambiguous-column | Column reference is ambiguous across tables | ✅ Implemented |
 | E0007 | join-type-mismatch | JOIN condition compares incompatible types | ✅ Implemented |
@@ -135,6 +135,7 @@ sqlsift check --schema schema/*.sql queries/**/*.sql
 - ✅ Arithmetic operations (`SELECT name + 10`)
 - ✅ JOIN conditions (`ON users.id = orders.user_name`)
 - ✅ Set operations column validation (`UNION` / `INTERSECT` / `EXCEPT` column count and type compatibility)
+- ✅ Potential NOT NULL violation checks for explicit `NULL` assignment in `INSERT` / `UPDATE` (`E0004`)
 - ✅ INSERT value type mismatches (`INSERT INTO users (id) VALUES ('text')`)
 - ✅ UPDATE assignment type mismatches (`UPDATE users SET id = 'text'`)
 - ✅ CAST expression type inference (`CAST(name AS INTEGER)`)

--- a/crates/sqlsift-core/CHANGELOG.md
+++ b/crates/sqlsift-core/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Implement `E0004` potential null-violation diagnostics for explicit `NULL` assignment to `NOT NULL` columns in `INSERT` / `UPDATE`
+- Add analyzer tests for `E0004` positive/negative cases
+
 ## [0.1.3](https://github.com/yukikotani231/sqlsift/compare/v0.1.2...v0.1.3) - 2026-03-04
 
 ### Added

--- a/crates/sqlsift-core/src/analyzer/type_resolver.rs
+++ b/crates/sqlsift-core/src/analyzer/type_resolver.rs
@@ -145,6 +145,25 @@ impl<'a> TypeResolver<'a> {
                             Some(def) => def,
                             None => continue, // Column not found - already reported
                         };
+
+                        if !col_def.nullable && matches!(value_expr, Expr::Value(Value::Null)) {
+                            let span = Span::from_sqlparser(&value_expr.span());
+                            self.diagnostics.push(
+                                Diagnostic::error(
+                                    DiagnosticKind::PotentialNullViolation,
+                                    format!(
+                                        "Potential NOT NULL violation: column '{}' cannot be assigned NULL",
+                                        col_name
+                                    ),
+                                )
+                                .with_span(span)
+                                .with_help(
+                                    "This column is defined as NOT NULL. Provide a non-NULL value or change the schema constraint.",
+                                ),
+                            );
+                            continue;
+                        }
+
                         let value_type = self.infer_expr_type(value_expr);
                         if let ExpressionType::Known(vt) = value_type {
                             let compat = vt.is_compatible_with(&col_def.data_type);
@@ -204,6 +223,24 @@ impl<'a> TypeResolver<'a> {
                 Some(def) => def,
                 None => continue, // Column not found - already reported
             };
+
+            if !col_def.nullable && matches!(&assignment.value, Expr::Value(Value::Null)) {
+                let span = Span::from_sqlparser(&assignment.value.span());
+                self.diagnostics.push(
+                    Diagnostic::error(
+                        DiagnosticKind::PotentialNullViolation,
+                        format!(
+                            "Potential NOT NULL violation: column '{}' cannot be assigned NULL",
+                            col_name
+                        ),
+                    )
+                    .with_span(span)
+                    .with_help(
+                        "This column is defined as NOT NULL. Provide a non-NULL value or change the schema constraint.",
+                    ),
+                );
+                continue;
+            }
 
             let value_type = self.infer_expr_type(&assignment.value);
             if let ExpressionType::Known(vt) = value_type {

--- a/crates/sqlsift-core/tests/analyzer_tests.rs
+++ b/crates/sqlsift-core/tests/analyzer_tests.rs
@@ -1672,15 +1672,31 @@ fn test_insert_type_compatible() {
 }
 
 #[test]
-fn test_insert_null_compatible() {
+fn test_insert_null_not_null_violation() {
     let catalog = setup_catalog();
     let mut analyzer = Analyzer::new(&catalog);
 
-    // NULL should be compatible with any column type
+    // id is SERIAL PRIMARY KEY (NOT NULL), inserting NULL should produce E0004.
     let diagnostics = analyzer.analyze("INSERT INTO users (id) VALUES (NULL)");
     assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.kind == DiagnosticKind::PotentialNullViolation),
+        "Expected NOT NULL violation for INSERT NULL into NOT NULL column: {:?}",
+        diagnostics
+    );
+}
+
+#[test]
+fn test_insert_null_nullable_compatible() {
+    let catalog = setup_catalog();
+    let mut analyzer = Analyzer::new(&catalog);
+
+    // email is nullable in setup_catalog()
+    let diagnostics = analyzer.analyze("INSERT INTO users (email) VALUES (NULL)");
+    assert!(
         diagnostics.is_empty(),
-        "NULL INSERT should have no errors: {:?}",
+        "NULL INSERT into nullable column should have no errors: {:?}",
         diagnostics
     );
 }
@@ -1712,6 +1728,36 @@ fn test_update_type_compatible() {
     assert!(
         diagnostics.is_empty(),
         "Compatible UPDATE should have no errors: {:?}",
+        diagnostics
+    );
+}
+
+#[test]
+fn test_update_null_not_null_violation() {
+    let catalog = setup_catalog();
+    let mut analyzer = Analyzer::new(&catalog);
+
+    // name is NOT NULL in setup_catalog()
+    let diagnostics = analyzer.analyze("UPDATE users SET name = NULL");
+    assert!(
+        diagnostics
+            .iter()
+            .any(|d| d.kind == DiagnosticKind::PotentialNullViolation),
+        "Expected NOT NULL violation for UPDATE NULL into NOT NULL column: {:?}",
+        diagnostics
+    );
+}
+
+#[test]
+fn test_update_null_nullable_compatible() {
+    let catalog = setup_catalog();
+    let mut analyzer = Analyzer::new(&catalog);
+
+    // email is nullable in setup_catalog()
+    let diagnostics = analyzer.analyze("UPDATE users SET email = NULL");
+    assert!(
+        diagnostics.is_empty(),
+        "NULL UPDATE into nullable column should have no errors: {:?}",
         diagnostics
     );
 }


### PR DESCRIPTION
## Summary
- implement E0004 diagnostics for explicit NULL assignment to NOT NULL columns in INSERT/UPDATE
- add analyzer tests for E0004 positive/negative scenarios
- update README and changelog entries to reflect E0004 implementation

## Testing
- cargo test -p sqlsift-core --test analyzer_tests