### PR TITLE
chore: release v0.1.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -921,7 +921,7 @@ dependencies = [
 
 [[package]]
 name = "sqlsift-cli"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "clap",
  "glob",
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "sqlsift-core"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "indexmap",
  "miette",
@@ -950,7 +950,7 @@ dependencies = [
 
 [[package]]
 name = "sqlsift-lsp"
-version = "0.1.3"
+version = "0.1.4"
 dependencies = [
  "glob",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 members = ["crates/sqlsift-core", "crates/sqlsift-cli", "crates/sqlsift-lsp"]
 
 [workspace.package]
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 license = "MIT"
 repository = "https://github.com/yukikotani231/sqlsift"
@@ -36,7 +36,7 @@ tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }
 
 # Internal crates
-sqlsift-core = { path = "crates/sqlsift-core", version = "0.1.3" }
+sqlsift-core = { path = "crates/sqlsift-core", version = "0.1.4" }
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/crates/sqlsift-cli/CHANGELOG.md
+++ b/crates/sqlsift-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/yukikotani231/sqlsift/compare/v0.1.3...v0.1.4) - 2026-03-04
+
+### Added
+
+- implement E0004 null-violation diagnostics ([#66](https://github.com/yukikotani231/sqlsift/pull/66))
+
 ## [0.1.3](https://github.com/yukikotani231/sqlsift/compare/v0.1.2...v0.1.3) - 2026-03-04
 
 ### Added

--- a/crates/sqlsift-core/CHANGELOG.md
+++ b/crates/sqlsift-core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/yukikotani231/sqlsift/compare/v0.1.3...v0.1.4) - 2026-03-04
+
+### Added
+
+- implement E0004 null-violation diagnostics ([#66](https://github.com/yukikotani231/sqlsift/pull/66))
+
 ### Added
 - Implement `E0004` potential null-violation diagnostics for explicit `NULL` assignment to `NOT NULL` columns in `INSERT` / `UPDATE`
 - Add analyzer tests for `E0004` positive/negative cases

--- a/crates/sqlsift-lsp/CHANGELOG.md
+++ b/crates/sqlsift-lsp/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/yukikotani231/sqlsift/compare/v0.1.3...v0.1.4) - 2026-03-04
+
+### Added
+
+- implement E0004 null-violation diagnostics ([#66](https://github.com/yukikotani231/sqlsift/pull/66))
+
 ## [0.1.3](https://github.com/yukikotani231/sqlsift/compare/v0.1.2...v0.1.3) - 2026-03-04
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `sqlsift-core`: 0.1.3 -> 0.1.4
* `sqlsift-cli`: 0.1.3 -> 0.1.4
* `sqlsift-lsp`: 0.1.3 -> 0.1.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `sqlsift-core`

<blockquote>

## [0.1.4](https://github.com/yukikotani231/sqlsift/compare/v0.1.3...v0.1.4) - 2026-03-04

### Added

- implement E0004 null-violation diagnostics ([#66](https://github.com/yukikotani231/sqlsift/pull/66))

### Added
- Implement `E0004` potential null-violation diagnostics for explicit `NULL` assignment to `NOT NULL` columns in `INSERT` / `UPDATE`
- Add analyzer tests for `E0004` positive/negative cases
</blockquote>

## `sqlsift-cli`

<blockquote>

## [0.1.4](https://github.com/yukikotani231/sqlsift/compare/v0.1.3...v0.1.4) - 2026-03-04

### Added

- implement E0004 null-violation diagnostics ([#66](https://github.com/yukikotani231/sqlsift/pull/66))
</blockquote>

## `sqlsift-lsp`

<blockquote>

## [0.1.4](https://github.com/yukikotani231/sqlsift/compare/v0.1.3...v0.1.4) - 2026-03-04

### Added

- implement E0004 null-violation diagnostics ([#66](https://github.com/yukikotani231/sqlsift/pull/66))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).